### PR TITLE
Add polygon ROI creation via single clicks with hover preview

### DIFF
--- a/templates/roi_selection.html
+++ b/templates/roi_selection.html
@@ -184,41 +184,33 @@
             const x = (e.clientX - rect.left) * scaleX;
             const y = (e.clientY - rect.top) * scaleY;
 
-            if (!drawingRect) {
-                rectStart = { x, y };
-                hoverPoint = null;
-                drawingRect = true;
-            } else {
+            currentPoints.push({ x, y });
+            if (currentPoints.length === 4) {
                 const roiId = prompt("ROI id?");
                 if (roiId !== null) {
                     let selectedModule = null;
                     if (modules.length > 0) {
                         selectedModule = prompt("Module? (" + modules.join(", ") + ")");
                     }
-                    const x1 = Math.min(rectStart.x, x);
-                    const y1 = Math.min(rectStart.y, y);
-                    const x2 = Math.max(rectStart.x, x);
-                    const y2 = Math.max(rectStart.y, y);
                     rois.push({
                         id: roiId,
                         module: selectedModule,
-                        points: [
-                            { x: x1, y: y1 },
-                            { x: x2, y: y1 },
-                            { x: x2, y: y2 },
-                            { x: x1, y: y2 }
-                        ]
+                        points: currentPoints.slice()
+                    });
+                    renderRoiList();
+                    fetch('/save_roi', {
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify({ rois: rois, source: currentSource })
                     });
                 }
-                drawingRect = false;
-                rectStart = null;
-                hoverPoint = null;
-                renderRoiList();
+                currentPoints = [];
             }
             drawAllRois();
         });
 
         frameContainer.addEventListener('dblclick', (e) => {
+            currentPoints = [];
             const rect = frameContainer.getBoundingClientRect();
             const scaleX = canvas.width / rect.width;
             const scaleY = canvas.height / rect.height;
@@ -261,16 +253,21 @@
         });
 
         frameContainer.addEventListener('mousemove', (e) => {
-            if (!drawingRect || !rectStart) return;
             const rect = frameContainer.getBoundingClientRect();
             const scaleX = canvas.width / rect.width;
             const scaleY = canvas.height / rect.height;
             const x = (e.clientX - rect.left) * scaleX;
             const y = (e.clientY - rect.top) * scaleY;
-            hoverPoint = {
-                x: Math.max(rectStart.x, x),
-                y: Math.max(rectStart.y, y)
-            };
+            if (drawingRect && rectStart) {
+                hoverPoint = {
+                    x: Math.max(rectStart.x, x),
+                    y: Math.max(rectStart.y, y)
+                };
+            } else if (currentPoints.length > 0) {
+                hoverPoint = { x, y };
+            } else {
+                hoverPoint = null;
+            }
             drawAllRois();
         });
 
@@ -308,6 +305,27 @@
                     ctx.fillText(r.id, r.points[0].x, Math.max(10, r.points[0].y - 5));
                 }
             });
+            if (currentPoints.length > 0) {
+                ctx.beginPath();
+                ctx.moveTo(currentPoints[0].x, currentPoints[0].y);
+                for (let i = 1; i < currentPoints.length; i++) {
+                    ctx.lineTo(currentPoints[i].x, currentPoints[i].y);
+                }
+                if (hoverPoint && !drawingRect) {
+                    ctx.lineTo(hoverPoint.x, hoverPoint.y);
+                }
+                ctx.strokeStyle = 'red';
+                ctx.lineWidth = 1;
+                ctx.setLineDash([5, 5]);
+                ctx.stroke();
+                ctx.setLineDash([]);
+                currentPoints.forEach(p => {
+                    ctx.beginPath();
+                    ctx.arc(p.x, p.y, 5, 0, 2 * Math.PI);
+                    ctx.fillStyle = 'red';
+                    ctx.fill();
+                });
+            }
             if (drawingRect && rectStart && hoverPoint) {
                 const x = Math.min(rectStart.x, hoverPoint.x);
                 const y = Math.min(rectStart.y, hoverPoint.y);

--- a/tests/test_roi_selection_click_polygon.py
+++ b/tests/test_roi_selection_click_polygon.py
@@ -5,17 +5,17 @@ import textwrap
 from pathlib import Path
 
 
-def test_dblclick_creates_rectangle_and_saves():
+def test_click_creates_polygon_and_saves():
     html = Path('templates/roi_selection.html').read_text()
-    match = re.search(r"frameContainer.addEventListener\('dblclick',\s*\(e\) => \{([\s\S]*?drawAllRois\(\);\n\s*)\}\);", html)
-    assert match, 'dblclick handler not found'
+    match = re.search(r"frameContainer.addEventListener\('click',\s*\(e\) => \{([\s\S]*?drawAllRois\(\);\n\s*)\}\);", html)
+    assert match, 'click handler not found'
     handler = match.group(1)
 
     script = textwrap.dedent("""
     let rois = [];
     let modules = ['m1'];
-    let rectStart = null, rectEnd = null, drawingRect = false;
     let currentPoints = [];
+    let drawingRect = false;
     let currentSource = 'src';
     let fetchBody;
     function renderRoiList(){}
@@ -31,8 +31,10 @@ def test_dblclick_creates_rectangle_and_saves():
     function handler(e) {
 {handler}
     }
-    handler({clientX:10, clientY:20});
-    handler({clientX:50, clientY:60});
+    handler({clientX:10, clientY:10});
+    handler({clientX:50, clientY:10});
+    handler({clientX:50, clientY:50});
+    handler({clientX:10, clientY:50});
     console.log(JSON.stringify({rois, fetchBody}));
     """).replace('{handler}', handler)
 
@@ -40,9 +42,9 @@ def test_dblclick_creates_rectangle_and_saves():
     data = json.loads(result.stdout.strip())
     assert len(data['rois']) == 1
     pts = data['rois'][0]['points']
-    assert pts[0] == {'x': 10, 'y': 20}
-    assert pts[1] == {'x': 50, 'y': 20}
-    assert pts[2] == {'x': 50, 'y': 60}
-    assert pts[3] == {'x': 10, 'y': 60}
+    assert pts[0] == {'x': 10, 'y': 10}
+    assert pts[1] == {'x': 50, 'y': 10}
+    assert pts[2] == {'x': 50, 'y': 50}
+    assert pts[3] == {'x': 10, 'y': 50}
     payload = json.loads(data['fetchBody'])
     assert payload['rois'][0]['points'] == pts

--- a/tests/test_roi_selection_mousemove_preview_polygon.py
+++ b/tests/test_roi_selection_mousemove_preview_polygon.py
@@ -1,0 +1,31 @@
+import json
+import re
+import subprocess
+import textwrap
+from pathlib import Path
+
+
+def test_mousemove_updates_hover_point_for_polygon():
+    html = Path('templates/roi_selection.html').read_text()
+    match = re.search(r"frameContainer.addEventListener\('mousemove',\s*\(e\) => \{([\s\S]*?)\}\);", html)
+    assert match, 'mousemove handler not found'
+    handler = match.group(1)
+
+    script = textwrap.dedent("""
+    let hoverPoint = null;
+    let currentPoints = [{x:10, y:10}];
+    let drawingRect = false;
+    let rectStart = null;
+    const frameContainer = { getBoundingClientRect: () => ({left:0, top:0, width:100, height:100}) };
+    const canvas = { width:100, height:100 };
+    function drawAllRois(){}
+    function handler(e) {
+    {handler}
+    }
+    handler({clientX:50, clientY:60});
+    console.log(JSON.stringify({hoverPoint}));
+    """).replace('{handler}', handler)
+
+    result = subprocess.run(['node', '-e', script], capture_output=True, text=True, check=True)
+    data = json.loads(result.stdout.strip())
+    assert data['hoverPoint'] == {'x': 50, 'y': 60}


### PR DESCRIPTION
## Summary
- Show dashed preview line from last clicked point to the mouse when defining polygon ROIs
- Track mouse position for polygon selection and render the temporary edge
- Test mousemove handler to ensure hover preview is updated

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6898af2053d4832ba7864475c8e8abff