### PR TITLE
refactor: centralize test stubs for quart and cv2

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+# Package marker for test utilities

--- a/tests/stubs.py
+++ b/tests/stubs.py
@@ -1,0 +1,41 @@
+import sys
+import types
+
+
+def stub_quart():
+    quart_stub = types.ModuleType("quart")
+
+    class DummyQuart:
+        def __init__(self, name):
+            self.config = {}
+
+        def route(self, *args, **kwargs):
+            def decorator(f):
+                return f
+            return decorator
+
+        def websocket(self, *args, **kwargs):
+            def decorator(f):
+                return f
+            return decorator
+
+    quart_stub.Quart = DummyQuart
+    quart_stub.render_template = lambda *a, **k: None
+    quart_stub.websocket = lambda *a, **k: None
+    quart_stub.request = None
+    quart_stub.jsonify = lambda *a, **k: None
+    quart_stub.send_file = lambda *a, **k: None
+    quart_stub.redirect = lambda *a, **k: None
+    sys.modules["quart"] = quart_stub
+    return quart_stub
+
+
+def stub_cv2():
+    cv2_stub = types.ModuleType("cv2")
+    cv2_stub.rectangle = lambda *a, **k: None
+    cv2_stub.putText = lambda *a, **k: None
+    cv2_stub.resize = lambda img, dsize, fx=0, fy=0, **k: img
+    cv2_stub.destroyAllWindows = lambda: None
+    cv2_stub.IMWRITE_JPEG_QUALITY = 1
+    sys.modules["cv2"] = cv2_stub
+    return cv2_stub

--- a/tests/test_event_loop.py
+++ b/tests/test_event_loop.py
@@ -2,39 +2,10 @@ import asyncio
 import contextlib
 import time
 
-import sys
-import types
+from .stubs import stub_cv2, stub_quart
 
-# สร้างโมดูล quart จำลองเพื่อหลีกเลี่ยงการติดตั้งจริง
-quart_stub = types.ModuleType("quart")
-
-
-class DummyQuart:
-    def __init__(self, name):
-        self.config = {}
-
-    def route(self, *args, **kwargs):
-        def decorator(f):
-            return f
-        return decorator
-
-    def websocket(self, *args, **kwargs):
-        def decorator(f):
-            return f
-        return decorator
-
-
-quart_stub.Quart = DummyQuart
-quart_stub.render_template = lambda *a, **k: None
-quart_stub.websocket = lambda *a, **k: None
-quart_stub.request = None
-quart_stub.jsonify = lambda *a, **k: None
-quart_stub.send_file = lambda *a, **k: None
-quart_stub.redirect = lambda *a, **k: None
-
-sys.modules["quart"] = quart_stub
-
-cv2_stub = types.ModuleType("cv2")
+quart_stub = stub_quart()
+cv2_stub = stub_cv2()
 
 
 class DummyCamera:
@@ -60,8 +31,6 @@ cv2_stub.rectangle = lambda *a, **k: None
 cv2_stub.putText = lambda *a, **k: None
 cv2_stub.resize = lambda img, dsize, fx=0, fy=0, **k: img
 cv2_stub.destroyAllWindows = lambda: None
-
-sys.modules["cv2"] = cv2_stub
 
 import app
 

--- a/tests/test_read_and_queue_frame.py
+++ b/tests/test_read_and_queue_frame.py
@@ -1,40 +1,9 @@
 import asyncio
-import sys
-import types
 
-# stub quart module
-quart_stub = types.ModuleType("quart")
+from .stubs import stub_cv2, stub_quart
 
-class DummyQuart:
-    def __init__(self, name):
-        self.config = {}
-
-    def route(self, *args, **kwargs):
-        def decorator(f):
-            return f
-        return decorator
-
-    def websocket(self, *args, **kwargs):
-        def decorator(f):
-            return f
-        return decorator
-
-quart_stub.Quart = DummyQuart
-quart_stub.render_template = lambda *a, **k: None
-quart_stub.websocket = lambda *a, **k: None
-quart_stub.request = None
-quart_stub.jsonify = lambda *a, **k: None
-quart_stub.send_file = lambda *a, **k: None
-quart_stub.redirect = lambda *a, **k: None
-sys.modules["quart"] = quart_stub
-
-# stub cv2 module
-cv2_stub = types.ModuleType("cv2")
-cv2_stub.rectangle = lambda *a, **k: None
-cv2_stub.putText = lambda *a, **k: None
-cv2_stub.resize = lambda img, dsize, fx=0, fy=0, **k: img
-cv2_stub.destroyAllWindows = lambda: None
-sys.modules["cv2"] = cv2_stub
+quart_stub = stub_quart()
+cv2_stub = stub_cv2()
 
 import app
 

--- a/tests/test_telegram_notify_thread_stop.py
+++ b/tests/test_telegram_notify_thread_stop.py
@@ -5,10 +5,9 @@ from pathlib import Path
 # เพิ่ม path ของ src เพื่อให้สามารถ import packages ได้
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 
-# stub cv2 module so import works without opencv
-cv2_stub = types.ModuleType("cv2")
-cv2_stub.IMWRITE_JPEG_QUALITY = 1
-sys.modules["cv2"] = cv2_stub
+from .stubs import stub_cv2
+
+cv2_stub = stub_cv2()
 
 # stub requests module and its submodules
 requests_stub = types.ModuleType("requests")


### PR DESCRIPTION
## Summary
- add shared stub helpers for quart and cv2
- update tests to reuse stub helpers
- mark test suite as a package for reliable stub imports

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6899766b8148832b93231f688ad587d8