### PR TITLE
Add optional camera resolution configuration

### DIFF
--- a/camera_worker.py
+++ b/camera_worker.py
@@ -6,10 +6,20 @@ import time
 class CameraWorker:
     """อ่านภาพจากกล้องในเธรดแยกแล้วส่งผ่าน asyncio.Queue"""
 
-    def __init__(self, src, loop: asyncio.AbstractEventLoop | None = None):
+    def __init__(
+        self,
+        src,
+        loop: asyncio.AbstractEventLoop | None = None,
+        width: int | None = None,
+        height: int | None = None,
+    ):
         self.src = src
         self.loop = loop or asyncio.get_event_loop()
         self.cap = cv2.VideoCapture(src)
+        if width is not None:
+            self.cap.set(cv2.CAP_PROP_FRAME_WIDTH, width)
+        if height is not None:
+            self.cap.set(cv2.CAP_PROP_FRAME_HEIGHT, height)
         self.queue: asyncio.Queue = asyncio.Queue(maxsize=1)
         self._stop = threading.Event()
         self._thread = threading.Thread(target=self._reader, daemon=True)

--- a/templates/create_source.html
+++ b/templates/create_source.html
@@ -13,6 +13,18 @@
         <label for="source" class="form-label">Source:</label>
         <input type="text" id="source" name="source" class="form-control" required>
     </div>
+    <div class="mb-3">
+        <label>
+            <input type="checkbox" id="width-toggle"> Width:
+        </label>
+        <input type="number" id="width" name="width" class="form-control d-inline-block" style="max-width:150px;" disabled>
+    </div>
+    <div class="mb-3">
+        <label>
+            <input type="checkbox" id="height-toggle"> Height:
+        </label>
+        <input type="number" id="height" name="height" class="form-control d-inline-block" style="max-width:150px;" disabled>
+    </div>
     <button type="submit" class="btn btn-primary">Create</button>
 </form>
 
@@ -30,6 +42,19 @@
 </table>
 
 <script>
+    const widthToggle = document.getElementById('width-toggle');
+    const widthInput = document.getElementById('width');
+    widthToggle.addEventListener('change', (e) => {
+        widthInput.disabled = !e.target.checked;
+        if (!e.target.checked) widthInput.value = '';
+    });
+    const heightToggle = document.getElementById('height-toggle');
+    const heightInput = document.getElementById('height');
+    heightToggle.addEventListener('change', (e) => {
+        heightInput.disabled = !e.target.checked;
+        if (!e.target.checked) heightInput.value = '';
+    });
+
     async function loadSources() {
         try {
             const resp = await fetch('/source_list');
@@ -81,6 +106,8 @@
             if (res.ok && data.status === 'created') {
                 showAlert('Source created', 'success');
                 e.target.reset();
+                widthInput.disabled = true;
+                heightInput.disabled = true;
                 await loadSources();
             } else {
                 showAlert(data.message || 'Create failed', 'error');

--- a/templates/partials/inference_content.html
+++ b/templates/partials/inference_content.html
@@ -144,7 +144,7 @@
             const camRes = await fetchWithStatus(`/set_camera/${cam}`, {
                 method: 'POST',
                 headers: {'Content-Type': 'application/json'},
-                body: JSON.stringify({ name, source: cfg.source, ...cfgNoModule })
+                body: JSON.stringify(cfgNoModule)
             });
             if (!camRes.ok) {
                 statusEl.innerText = 'Camera error';

--- a/templates/roi_selection.html
+++ b/templates/roi_selection.html
@@ -132,10 +132,11 @@
             startBtn.disabled = true;
             currentSource = name;
             const cfg = await fetch(`/source_config?name=${encodeURIComponent(name)}`).then(r => r.json());
+            const { module, ...cfgNoModule } = cfg;
             const setRes = await fetch(`/set_camera/${cam}`, {
                 method: "POST",
                 headers: { "Content-Type": "application/json" },
-                body: JSON.stringify({ name, source: cfg.source })
+                body: JSON.stringify(cfgNoModule)
             });
             if (!setRes.ok) {
                 if (typeof showAlert === 'function') showAlert('Failed to set camera', 'error');

--- a/tests/test_camera_worker_resolution.py
+++ b/tests/test_camera_worker_resolution.py
@@ -1,0 +1,38 @@
+import asyncio
+
+
+def test_camera_worker_sets_resolution():
+    import app
+
+    class DummyCap:
+        def __init__(self, src):
+            self.src = src
+            self.settings = {}
+
+        def isOpened(self):
+            return True
+
+        def read(self):
+            return True, b"frame"
+
+        def set(self, prop, value):
+            self.settings[prop] = value
+
+        def release(self):
+            pass
+
+    orig_vc = app.cv2.VideoCapture
+    orig_w = getattr(app.cv2, "CAP_PROP_FRAME_WIDTH", 3)
+    orig_h = getattr(app.cv2, "CAP_PROP_FRAME_HEIGHT", 4)
+    app.cv2.CAP_PROP_FRAME_WIDTH = 3
+    app.cv2.CAP_PROP_FRAME_HEIGHT = 4
+    app.cv2.VideoCapture = DummyCap
+    try:
+        loop = asyncio.new_event_loop()
+        worker = app.CameraWorker(0, loop, width=640, height=480)
+        assert worker.cap.settings[app.cv2.CAP_PROP_FRAME_WIDTH] == 640
+        assert worker.cap.settings[app.cv2.CAP_PROP_FRAME_HEIGHT] == 480
+    finally:
+        app.cv2.VideoCapture = orig_vc
+        app.cv2.CAP_PROP_FRAME_WIDTH = orig_w
+        app.cv2.CAP_PROP_FRAME_HEIGHT = orig_h


### PR DESCRIPTION
## Summary
- Allow specifying optional camera width/height when creating a source and save to config
- Use stored resolution when opening cameras for ROI and inference
- Add tests for camera worker resolution handling

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689978857ba8832b99c71744686669ee