### PR TITLE
Show width and height in source list

### DIFF
--- a/app.py
+++ b/app.py
@@ -600,6 +600,8 @@ async def source_list():
                 {
                     "name": cfg.get("name", d.name),
                     "source": cfg.get("source", ""),
+                    "width": cfg.get("width"),
+                    "height": cfg.get("height"),
                 }
             )
     except FileNotFoundError:

--- a/templates/create_source.html
+++ b/templates/create_source.html
@@ -34,6 +34,8 @@
         <tr>
             <th>Name</th>
             <th>Source</th>
+            <th>Width</th>
+            <th>Height</th>
             <th>Actions</th>
         </tr>
     </thead>
@@ -68,6 +70,10 @@
                 nameTd.textContent = src.name;
                 const sourceTd = document.createElement('td');
                 sourceTd.textContent = src.source;
+                const widthTd = document.createElement('td');
+                widthTd.textContent = src.width ?? '';
+                const heightTd = document.createElement('td');
+                heightTd.textContent = src.height ?? '';
                 const actionTd = document.createElement('td');
                 const delBtn = document.createElement('button');
                 delBtn.textContent = 'Delete';
@@ -87,6 +93,8 @@
                 actionTd.appendChild(delBtn);
                 tr.appendChild(nameTd);
                 tr.appendChild(sourceTd);
+                tr.appendChild(widthTd);
+                tr.appendChild(heightTd);
                 tr.appendChild(actionTd);
                 tbody.appendChild(tr);
             });


### PR DESCRIPTION
## Summary
- expose width and height values via `/source_list`
- display width and height columns in the Create Source page

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68997b591128832b882d6b0374012748