### PR TITLE
ป้องกัน segmentation fault เมื่อบันทึกรูปหลาย ROI

### DIFF
--- a/inference_modules/easy_ocr/custom.py
+++ b/inference_modules/easy_ocr/custom.py
@@ -65,11 +65,16 @@ def _get_reader() -> easyocr.Reader:
 last_ocr_times: dict = {}
 last_ocr_results: dict = {}
 _last_ocr_lock = threading.Lock()
+_imwrite_lock = threading.Lock()
 
 
 def _save_image_async(path, image) -> None:
     """บันทึกรูปภาพแบบแยกเธรด"""
-    cv2.imwrite(path, image)
+    try:
+        with _imwrite_lock:
+            cv2.imwrite(path, image)
+    except Exception as e:  # pragma: no cover
+        logger.exception(f"Failed to save image {path}: {e}")
 
 
 def _run_ocr_async(frame, roi_id, save, source) -> None:

--- a/inference_modules/yolo/custom.py
+++ b/inference_modules/yolo/custom.py
@@ -51,12 +51,17 @@ def _configure_logger(source: str | None) -> None:
 # ตัวแปรควบคุมเวลาเรียก OCR แยกตาม roi พร้อมตัวล็อกป้องกันการเข้าถึงพร้อมกัน
 last_ocr_times = {}
 _last_ocr_lock = threading.Lock()
+_imwrite_lock = threading.Lock()
 
 
 
 def _save_image_async(path, image):
     """บันทึกรูปภาพแบบแยกเธรด"""
-    cv2.imwrite(path, image)
+    try:
+        with _imwrite_lock:
+            cv2.imwrite(path, image)
+    except Exception as e:  # pragma: no cover
+        logger.exception(f"Failed to save image {path}: {e}")
 
 
 def process(frame, roi_id=None, save=False, source=""):

--- a/tests/test_thread_safe_imwrite.py
+++ b/tests/test_thread_safe_imwrite.py
@@ -1,0 +1,44 @@
+from concurrent.futures import ThreadPoolExecutor
+
+import sys
+import types
+
+import pytest
+
+
+np = pytest.importorskip("numpy")
+
+
+# สร้างโมดูล PIL แบบจำลองเพื่อหลีกเลี่ยงการติดตั้งจริง
+pil_image_module = types.ModuleType("PIL.Image")
+
+
+class DummyImage:  # pragma: no cover - โครงร่างสำหรับการตรวจสอบ isinstance
+    pass
+
+
+pil_image_module.Image = DummyImage
+pil_package = types.ModuleType("PIL")
+pil_package.Image = pil_image_module
+sys.modules["PIL"] = pil_package
+sys.modules["PIL.Image"] = pil_image_module
+
+
+from inference_modules.easy_ocr import custom as mod
+
+
+def test_process_multiple_roi_thread_safe(tmp_path, monkeypatch):
+    """เรียก process พร้อมกันหลาย ROI เพื่อทดสอบว่าการบันทึกรูปปลอดภัย"""
+
+    monkeypatch.setattr(mod, "_data_sources_root", tmp_path)
+
+    frame = np.zeros((10, 10, 3), dtype=np.uint8)
+
+    def _call(i):
+        return mod.process(frame.copy(), roi_id=i, save=True, source="test")
+
+    with ThreadPoolExecutor(max_workers=5) as ex:
+        futures = [ex.submit(_call, i) for i in range(5)]
+        results = [f.result() for f in futures]
+
+    assert len(results) == 5


### PR DESCRIPTION
## Summary
- ป้องกันการบันทึกภาพพร้อมกันของหลาย ROI ด้วยล็อกของ OpenCV
- เพิ่มการทดสอบการเรียก process หลายเธรดพร้อมกัน

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689981bbf3bc832bb117113fc9a17496