### PR TITLE
เพิ่มเครื่องมือแนวตั้งและโหมดสี่เหลี่ยมแบบคลิกสองครั้ง

### DIFF
--- a/templates/roi_selection.html
+++ b/templates/roi_selection.html
@@ -9,6 +9,10 @@
 
 <br><br>
 <div id="frameContainer" style="position: relative; display: inline-block;">
+    <div id="toolMenu" style="position:absolute; top:10px; left:10px; display:flex; flex-direction:column; gap:5px; z-index:10;">
+        <button id="pickToolBtn">Pick Points</button>
+        <button id="rectToolBtn">Rectangle</button>
+    </div>
     <img id="video" />
     <canvas id="canvas"></canvas>
 </div>
@@ -32,6 +36,7 @@
         let isStreaming = false;
         let hasStarted = false;
         const cam = 1;
+        let currentTool = 'pick';
 
         const video = document.getElementById("video");
         const canvas = document.getElementById("canvas");
@@ -39,6 +44,32 @@
         const ctx = canvas.getContext("2d");
         const startBtn = document.getElementById("startBtn");
         const stopBtn = document.getElementById("stopBtn");
+        const pickToolBtn = document.getElementById("pickToolBtn");
+        const rectToolBtn = document.getElementById("rectToolBtn");
+
+        pickToolBtn.classList.add('active');
+        pickToolBtn.addEventListener('click', (e) => {
+            e.stopPropagation();
+            currentTool = 'pick';
+            currentPoints = [];
+            drawingRect = false;
+            rectStart = null;
+            hoverPoint = null;
+            pickToolBtn.classList.add('active');
+            rectToolBtn.classList.remove('active');
+            drawAllRois();
+        });
+        rectToolBtn.addEventListener('click', (e) => {
+            e.stopPropagation();
+            currentTool = 'rect';
+            currentPoints = [];
+            drawingRect = false;
+            rectStart = null;
+            hoverPoint = null;
+            pickToolBtn.classList.remove('active');
+            rectToolBtn.classList.add('active');
+            drawAllRois();
+        });
 
         video.onload = () => {
             if (!initialized || canvas.width !== video.naturalWidth || canvas.height !== video.naturalHeight) {
@@ -177,77 +208,70 @@
         }
 
         frameContainer.addEventListener('click', (e) => {
-            if (drawingRect) return;
             const rect = frameContainer.getBoundingClientRect();
             const scaleX = canvas.width / rect.width;
             const scaleY = canvas.height / rect.height;
             const x = (e.clientX - rect.left) * scaleX;
             const y = (e.clientY - rect.top) * scaleY;
 
-            currentPoints.push({ x, y });
-            if (currentPoints.length === 4) {
-                const roiId = prompt("ROI id?");
-                if (roiId !== null) {
-                    let selectedModule = null;
-                    if (modules.length > 0) {
-                        selectedModule = prompt("Module? (" + modules.join(", ") + ")");
+            if (currentTool === 'pick' && !drawingRect) {
+                currentPoints.push({ x, y });
+                if (currentPoints.length === 4) {
+                    const roiId = prompt("ROI id?");
+                    if (roiId !== null) {
+                        let selectedModule = null;
+                        if (modules.length > 0) {
+                            selectedModule = prompt("Module? (" + modules.join(", ") + ")");
+                        }
+                        rois.push({
+                            id: roiId,
+                            module: selectedModule,
+                            points: currentPoints.slice()
+                        });
+                        renderRoiList();
+                        fetch('/save_roi', {
+                            method: 'POST',
+                            headers: { 'Content-Type': 'application/json' },
+                            body: JSON.stringify({ rois: rois, source: currentSource })
+                        });
                     }
-                    rois.push({
-                        id: roiId,
-                        module: selectedModule,
-                        points: currentPoints.slice()
-                    });
-                    renderRoiList();
-                    fetch('/save_roi', {
-                        method: 'POST',
-                        headers: { 'Content-Type': 'application/json' },
-                        body: JSON.stringify({ rois: rois, source: currentSource })
-                    });
+                    currentPoints = [];
                 }
-                currentPoints = [];
-            }
-            drawAllRois();
-        });
-
-        frameContainer.addEventListener('dblclick', (e) => {
-            currentPoints = [];
-            const rect = frameContainer.getBoundingClientRect();
-            const scaleX = canvas.width / rect.width;
-            const scaleY = canvas.height / rect.height;
-            const x = (e.clientX - rect.left) * scaleX;
-            const y = (e.clientY - rect.top) * scaleY;
-            if (!rectStart) {
-                rectStart = { x, y };
-                drawingRect = true;
-            } else if (drawingRect) {
-                rectEnd = { x, y };
-                const x1 = Math.min(rectStart.x, rectEnd.x);
-                const y1 = Math.min(rectStart.y, rectEnd.y);
-                const x2 = Math.max(rectStart.x, rectEnd.x);
-                const y2 = Math.max(rectStart.y, rectEnd.y);
-                const points = [
-                    { x: x1, y: y1 },
-                    { x: x2, y: y1 },
-                    { x: x2, y: y2 },
-                    { x: x1, y: y2 }
-                ];
-                const roiId = prompt("ROI id?");
-                if (roiId !== null) {
-                    let selectedModule = null;
-                    if (modules.length > 0) {
-                        selectedModule = prompt("Module? (" + modules.join(", ") + ")");
+            } else if (currentTool === 'rect') {
+                if (!drawingRect) {
+                    rectStart = { x, y };
+                    drawingRect = true;
+                } else {
+                    rectEnd = { x, y };
+                    const x1 = Math.min(rectStart.x, rectEnd.x);
+                    const y1 = Math.min(rectStart.y, rectEnd.y);
+                    const x2 = Math.max(rectStart.x, rectEnd.x);
+                    const y2 = Math.max(rectStart.y, rectEnd.y);
+                    const points = [
+                        { x: x1, y: y1 },
+                        { x: x2, y: y1 },
+                        { x: x2, y: y2 },
+                        { x: x1, y: y2 }
+                    ];
+                    const roiId = prompt("ROI id?");
+                    if (roiId !== null) {
+                        let selectedModule = null;
+                        if (modules.length > 0) {
+                            selectedModule = prompt("Module? (" + modules.join(", ") + ")");
+                        }
+                        rois.push({ id: roiId, module: selectedModule, points });
+                        renderRoiList();
+                        fetch('/save_roi', {
+                            method: 'POST',
+                            headers: { 'Content-Type': 'application/json' },
+                            body: JSON.stringify({ rois: rois, source: currentSource })
+                        });
                     }
-                    rois.push({ id: roiId, module: selectedModule, points });
-                    renderRoiList();
-                    fetch('/save_roi', {
-                        method: 'POST',
-                        headers: { 'Content-Type': 'application/json' },
-                        body: JSON.stringify({ rois: rois, source: currentSource })
-                    });
+                    rectStart = null;
+                    rectEnd = null;
+                    drawingRect = false;
+                    hoverPoint = null;
                 }
-                rectStart = null;
-                rectEnd = null;
-                drawingRect = false;
             }
             drawAllRois();
         });
@@ -258,12 +282,9 @@
             const scaleY = canvas.height / rect.height;
             const x = (e.clientX - rect.left) * scaleX;
             const y = (e.clientY - rect.top) * scaleY;
-            if (drawingRect && rectStart) {
-                hoverPoint = {
-                    x: Math.max(rectStart.x, x),
-                    y: Math.max(rectStart.y, y)
-                };
-            } else if (currentPoints.length > 0) {
+            if (drawingRect && rectStart && currentTool === 'rect') {
+                hoverPoint = { x, y };
+            } else if (currentPoints.length > 0 && currentTool === 'pick') {
                 hoverPoint = { x, y };
             } else {
                 hoverPoint = null;
@@ -273,7 +294,7 @@
 
         frameContainer.addEventListener('mouseleave', () => {
             hoverPoint = null;
-            if (drawingRect) {
+            if (drawingRect && currentTool === 'rect') {
                 drawingRect = false;
                 rectStart = null;
             }
@@ -338,16 +359,6 @@
                 ctx.lineWidth = 1;
                 ctx.strokeRect(x, y, w, h);
                 ctx.restore();
-            }
-            if (drawingRect && rectStart) {
-                const end = hoverPoint || rectStart;
-                ctx.beginPath();
-                ctx.rect(rectStart.x, rectStart.y, end.x - rectStart.x, end.y - rectStart.y);
-                ctx.strokeStyle = 'red';
-                ctx.lineWidth = 1;
-                ctx.setLineDash([5, 5]);
-                ctx.stroke();
-                ctx.setLineDash([]);
             }
         }
 

--- a/tests/test_roi_selection_click_polygon.py
+++ b/tests/test_roi_selection_click_polygon.py
@@ -16,7 +16,11 @@ def test_click_creates_polygon_and_saves():
     let modules = ['m1'];
     let currentPoints = [];
     let drawingRect = false;
+    let rectStart = null;
+    let rectEnd = null;
+    let hoverPoint = null;
     let currentSource = 'src';
+    let currentTool = 'pick';
     let fetchBody;
     function renderRoiList(){}
     function drawAllRois(){}

--- a/tests/test_roi_selection_click_rect.py
+++ b/tests/test_roi_selection_click_rect.py
@@ -5,10 +5,10 @@ import textwrap
 from pathlib import Path
 
 
-def test_dblclick_creates_rectangle_and_saves():
+def test_click_creates_rectangle_and_saves():
     html = Path('templates/roi_selection.html').read_text()
-    match = re.search(r"frameContainer.addEventListener\('dblclick',\s*\(e\) => \{([\s\S]*?drawAllRois\(\);\n\s*)\}\);", html)
-    assert match, 'dblclick handler not found'
+    match = re.search(r"frameContainer.addEventListener\('click',\s*\(e\) => \{([\s\S]*?drawAllRois\(\);\n\s*)\}\);", html)
+    assert match, 'click handler not found'
     handler = match.group(1)
 
     script = textwrap.dedent("""
@@ -18,6 +18,8 @@ def test_dblclick_creates_rectangle_and_saves():
     let currentPoints = [];
     let currentSource = 'src';
     let fetchBody;
+    let hoverPoint = null;
+    let currentTool = 'rect';
     function renderRoiList(){}
     function drawAllRois(){}
     global.prompt = (msg) => {

--- a/tests/test_roi_selection_mousemove_preview_rect.py
+++ b/tests/test_roi_selection_mousemove_preview_rect.py
@@ -5,7 +5,7 @@ import textwrap
 from pathlib import Path
 
 
-def test_mousemove_updates_hover_point_for_polygon():
+def test_mousemove_updates_hover_point_for_rectangle():
     html = Path('templates/roi_selection.html').read_text()
     match = re.search(r"frameContainer.addEventListener\('mousemove',\s*\(e\) => \{([\s\S]*?)\}\);", html)
     assert match, 'mousemove handler not found'
@@ -13,14 +13,14 @@ def test_mousemove_updates_hover_point_for_polygon():
 
     script = textwrap.dedent("""
     let hoverPoint = null;
-    let currentPoints = [{x:10, y:10}];
-    let drawingRect = false;
-    let rectStart = null;
-    let currentTool = 'pick';
+    let currentPoints = [];
+    let drawingRect = true;
+    let rectStart = {x:10, y:20};
+    let currentTool = 'rect';
     const frameContainer = { getBoundingClientRect: () => ({left:0, top:0, width:100, height:100}) };
     const canvas = { width:100, height:100 };
     function drawAllRois(){}
-    function handler(e) {
+    function handler(e){
     {handler}
     }
     handler({clientX:50, clientY:60});


### PR DESCRIPTION
## Summary
- ย้ายปุ่มเลือกเครื่องมือมาแสดงซ้อนหน้าวิดีโอและจัดเรียงแนวตั้ง
- ปรับโหมด Rectangle ให้คลิกครั้งแรกกำหนดมุมและคลิกครั้งที่สองบันทึก ROI พร้อมแสดงกรอบระหว่างเลื่อนเมาส์
- เพิ่มและปรับปรุงชุดทดสอบรองรับการคลิกสองครั้งและการแสดงกรอบแบบโฮเวอร์

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689bf0c19e70832baf1125a52ae24021