### PR TITLE
คืนปุ่ม Start/Stop และตัดเมนู Pick/Rectangle แนวนอน

### DIFF
--- a/templates/roi_selection.html
+++ b/templates/roi_selection.html
@@ -132,11 +132,10 @@
             startBtn.disabled = true;
             currentSource = name;
             const cfg = await fetch(`/source_config?name=${encodeURIComponent(name)}`).then(r => r.json());
-            const { module, ...cfgNoModule } = cfg;
             const setRes = await fetch(`/set_camera/${cam}`, {
                 method: "POST",
                 headers: { "Content-Type": "application/json" },
-                body: JSON.stringify(cfgNoModule)
+                body: JSON.stringify({ name, source: cfg.source })
             });
             if (!setRes.ok) {
                 if (typeof showAlert === 'function') showAlert('Failed to set camera', 'error');

--- a/tests/test_roi_selection_buttons.py
+++ b/tests/test_roi_selection_buttons.py
@@ -1,0 +1,8 @@
+import pathlib
+
+def test_start_stop_and_no_tool_buttons():
+    html = pathlib.Path('templates/roi_selection.html').read_text()
+    assert 'id="startBtn"' in html
+    assert 'id="stopBtn"' in html
+    assert 'id="pickToolBtn"' not in html
+    assert 'id="rectToolBtn"' not in html

--- a/tests/test_roi_selection_click_polygon.py
+++ b/tests/test_roi_selection_click_polygon.py
@@ -16,6 +16,9 @@ def test_click_creates_polygon_and_saves():
     let modules = ['m1'];
     let currentPoints = [];
     let drawingRect = false;
+    let rectStart = null;
+    let rectEnd = null;
+    let hoverPoint = null;
     let currentSource = 'src';
     let fetchBody;
     function renderRoiList(){}

--- a/tests/test_roi_selection_dblclick_rect.py
+++ b/tests/test_roi_selection_dblclick_rect.py
@@ -18,6 +18,7 @@ def test_dblclick_creates_rectangle_and_saves():
     let currentPoints = [];
     let currentSource = 'src';
     let fetchBody;
+    let hoverPoint = null;
     function renderRoiList(){}
     function drawAllRois(){}
     global.prompt = (msg) => {

--- a/tests/test_roi_selection_mousemove_preview_rect.py
+++ b/tests/test_roi_selection_mousemove_preview_rect.py
@@ -1,0 +1,31 @@
+import json
+import re
+import subprocess
+import textwrap
+from pathlib import Path
+
+
+def test_mousemove_updates_hover_point_for_rectangle():
+    html = Path('templates/roi_selection.html').read_text()
+    match = re.search(r"frameContainer.addEventListener\('mousemove',\s*\(e\) => \{([\s\S]*?)\}\);", html)
+    assert match, 'mousemove handler not found'
+    handler = match.group(1)
+
+    script = textwrap.dedent("""
+    let hoverPoint = null;
+    let currentPoints = [];
+    let drawingRect = true;
+    let rectStart = {x:10, y:20};
+    const frameContainer = { getBoundingClientRect: () => ({left:0, top:0, width:100, height:100}) };
+    const canvas = { width:100, height:100 };
+    function drawAllRois(){}
+    function handler(e){
+    {handler}
+    }
+    handler({clientX:50, clientY:60});
+    console.log(JSON.stringify({hoverPoint}));
+    """).replace('{handler}', handler)
+
+    result = subprocess.run(['node', '-e', script], capture_output=True, text=True, check=True)
+    data = json.loads(result.stdout.strip())
+    assert data['hoverPoint'] == {'x': 50, 'y': 60}


### PR DESCRIPTION
## Summary
- นำปุ่ม Start และ Stop กลับมาบนหน้าเลือก ROI และตัดปุ่ม Pick Points/Rectangle ที่เคยวางแนวนอนออก
- คืนพฤติกรรมการสร้างสี่เหลี่ยมด้วยการดับเบิลคลิกสองจุด
- ปรับชุดทดสอบให้ตรวจสอบปุ่ม Start/Stop และการสร้างสี่เหลี่ยมด้วยดับเบิลคลิก

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689bf0c19e70832baf1125a52ae24021