### PR TITLE
Add ROI group field for ROI selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,7 +258,8 @@ data_sources/
 [
   {
     "id": "1",
-    "module": "typhoon_ocr",
+    "group": "g1",
+    "module": "",
     "points": [
       {"x": 10, "y": 20},
       {"x": 110, "y": 20},
@@ -268,6 +269,8 @@ data_sources/
   }
 ]
 ```
+
+แต่ละ ROI สามารถกำหนด `group` สำหรับเลือก group id ได้ ส่วนค่า `module` จะเริ่มต้นเป็นค่าว่าง
 
 โมดูลสำหรับประมวลผลจะเก็บไว้ในโฟลเดอร์ `inference_modules/<module_name>/custom.py`
 

--- a/app.py
+++ b/app.py
@@ -579,6 +579,30 @@ async def list_inference_modules():
     return jsonify(names)
 
 
+@app.route("/groups")
+async def list_groups():
+    base_dir = Path(__file__).resolve().parent / "data_sources"
+    groups: set[str] = set()
+    try:
+        for d in base_dir.iterdir():
+            if not d.is_dir():
+                continue
+            roi_path = d / "rois.json"
+            if not roi_path.exists():
+                continue
+            try:
+                data = json.loads(roi_path.read_text())
+                for r in data:
+                    g = r.get("group")
+                    if g:
+                        groups.add(str(g))
+            except Exception:
+                continue
+    except FileNotFoundError:
+        pass
+    return jsonify(sorted(groups))
+
+
 @app.route("/source_list", methods=["GET"])
 async def source_list():
     base_dir = Path(__file__).resolve().parent / "data_sources"

--- a/templates/roi_selection.html
+++ b/templates/roi_selection.html
@@ -27,7 +27,7 @@
         let drawingRect = false;
 
         let currentSource = "";
-        let modules = [];
+        let groups = [];
         let initialized = false;
         let isStreaming = false;
         let hasStarted = false;
@@ -68,17 +68,17 @@
             });
         }
 
-        async function loadModules() {
+        // Load available groups from server (if any)
+        async function loadGroups() {
             try {
-                const res = await fetch('/inference_modules');
+                const res = await fetch('/groups');
                 if (!res.ok) throw new Error('Bad response');
-                modules = await res.json();
-                renderRoiList();
+                groups = await res.json();
             } catch (err) {
-                console.error('Failed to load modules', err);
-                modules = [];
-                renderRoiList();
+                console.error('Failed to load groups', err);
+                groups = [];
             }
+            renderRoiList();
         }
 
         function openSocket() {
@@ -188,13 +188,11 @@
             if (currentPoints.length === 4) {
                 const roiId = prompt("ROI id?");
                 if (roiId !== null) {
-                    let selectedModule = null;
-                    if (modules.length > 0) {
-                        selectedModule = prompt("Module? (" + modules.join(", ") + ")");
-                    }
+                    const groupId = prompt("Group id?");
                     rois.push({
                         id: roiId,
-                        module: selectedModule,
+                        group: groupId,
+                        module: "",
                         points: currentPoints.slice()
                     });
                     renderRoiList();
@@ -233,11 +231,8 @@
                 ];
                 const roiId = prompt("ROI id?");
                 if (roiId !== null) {
-                    let selectedModule = null;
-                    if (modules.length > 0) {
-                        selectedModule = prompt("Module? (" + modules.join(", ") + ")");
-                    }
-                    rois.push({ id: roiId, module: selectedModule, points });
+                    const groupId = prompt("Group id?");
+                    rois.push({ id: roiId, group: groupId, module: "", points });
                     renderRoiList();
                     fetch('/save_roi', {
                         method: 'POST',
@@ -362,7 +357,7 @@
             table.className = 'table table-striped table-sm';
             const thead = document.createElement('thead');
             const headerRow = document.createElement('tr');
-            ['ID', 'x', 'y', 'w', 'h', 'Module', 'Delete'].forEach(col => {
+            ['ID', 'x', 'y', 'w', 'h', 'Group', 'Delete'].forEach(col => {
                 const th = document.createElement('th');
                 th.textContent = col;
                 headerRow.appendChild(th);
@@ -387,23 +382,13 @@
                     td.textContent = Math.round(val);
                     tr.appendChild(td);
                 });
-                const tdModule = document.createElement('td');
-                const select = document.createElement('select');
-                select.className = 'form-select form-select-sm';
-                const empty = document.createElement('option');
-                empty.value = '';
-                empty.textContent = '';
-                select.appendChild(empty);
-                modules.forEach(m => {
-                    const opt = document.createElement('option');
-                    opt.value = m;
-                    opt.textContent = m;
-                    select.appendChild(opt);
-                });
-                select.value = r.module || '';
-                select.addEventListener('change', e => updateRoiModule(idx, e.target.value));
-                tdModule.appendChild(select);
-                tr.appendChild(tdModule);
+                const tdGroup = document.createElement('td');
+                const input = document.createElement('input');
+                input.className = 'form-control form-control-sm';
+                input.value = r.group || '';
+                input.addEventListener('change', e => updateRoiGroup(idx, e.target.value));
+                tdGroup.appendChild(input);
+                tr.appendChild(tdGroup);
 
                 const tdDel = document.createElement('td');
                 const delBtn = document.createElement('button');
@@ -440,7 +425,8 @@
                 }
                 return {
                     id: r.id ?? String(idx + 1),
-                    module: r.module ?? null,
+                    group: r.group ?? null,
+                    module: r.module ?? "",
                     points: pts || []
                 };
             });
@@ -473,8 +459,8 @@
             });
         }
 
-        function updateRoiModule(i, module) {
-            rois[i].module = module;
+        function updateRoiGroup(i, group) {
+            rois[i].group = group;
             fetch('/save_roi', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
@@ -507,7 +493,7 @@
         window.startStream = startStream;
         window.stopStream = stopStream;
         window.clearAllRois = clearAllRois;
-        window.updateRoiModule = updateRoiModule;
+        window.updateRoiGroup = updateRoiGroup;
         window.deleteRoi = deleteRoi;
 
         window.addEventListener('beforeunload', () => {
@@ -516,7 +502,7 @@
 
         (async () => {
             await loadSources();
-            await loadModules();
+            await loadGroups();
             await checkStatus();
             if (typeof showAlert === 'function') showAlert('ROI selection ready', 'success');
         })();

--- a/tests/test_roi_selection_click_polygon.py
+++ b/tests/test_roi_selection_click_polygon.py
@@ -13,7 +13,6 @@ def test_click_creates_polygon_and_saves():
 
     script = textwrap.dedent("""
     let rois = [];
-    let modules = ['m1'];
     let currentPoints = [];
     let drawingRect = false;
     let currentSource = 'src';
@@ -22,7 +21,7 @@ def test_click_creates_polygon_and_saves():
     function drawAllRois(){}
     global.prompt = (msg) => {
         if (msg === 'ROI id?') return '1';
-        if (msg.startsWith('Module?')) return 'm1';
+        if (msg === 'Group id?') return 'g1';
         return null;
     };
     global.fetch = (url, opts) => { fetchBody = opts.body; return Promise.resolve({}); };
@@ -46,5 +45,9 @@ def test_click_creates_polygon_and_saves():
     assert pts[1] == {'x': 50, 'y': 10}
     assert pts[2] == {'x': 50, 'y': 50}
     assert pts[3] == {'x': 10, 'y': 50}
+    assert data['rois'][0]['group'] == 'g1'
+    assert data['rois'][0]['module'] == ''
     payload = json.loads(data['fetchBody'])
     assert payload['rois'][0]['points'] == pts
+    assert payload['rois'][0]['group'] == 'g1'
+    assert payload['rois'][0]['module'] == ''

--- a/tests/test_roi_selection_dblclick_rect.py
+++ b/tests/test_roi_selection_dblclick_rect.py
@@ -13,7 +13,6 @@ def test_dblclick_creates_rectangle_and_saves():
 
     script = textwrap.dedent("""
     let rois = [];
-    let modules = ['m1'];
     let rectStart = null, rectEnd = null, drawingRect = false;
     let currentPoints = [];
     let currentSource = 'src';
@@ -22,7 +21,7 @@ def test_dblclick_creates_rectangle_and_saves():
     function drawAllRois(){}
     global.prompt = (msg) => {
         if (msg === 'ROI id?') return '1';
-        if (msg.startsWith('Module?')) return 'm1';
+        if (msg === 'Group id?') return 'g1';
         return null;
     };
     global.fetch = (url, opts) => { fetchBody = opts.body; return Promise.resolve({}); };
@@ -44,5 +43,9 @@ def test_dblclick_creates_rectangle_and_saves():
     assert pts[1] == {'x': 50, 'y': 20}
     assert pts[2] == {'x': 50, 'y': 60}
     assert pts[3] == {'x': 10, 'y': 60}
+    assert data['rois'][0]['group'] == 'g1'
+    assert data['rois'][0]['module'] == ''
     payload = json.loads(data['fetchBody'])
     assert payload['rois'][0]['points'] == pts
+    assert payload['rois'][0]['group'] == 'g1'
+    assert payload['rois'][0]['module'] == ''

--- a/tests/test_roi_selection_update_group.py
+++ b/tests/test_roi_selection_update_group.py
@@ -5,25 +5,25 @@ import textwrap
 from pathlib import Path
 
 
-def test_update_roi_module_triggers_save():
+def test_update_roi_group_triggers_save():
     html = Path('templates/roi_selection.html').read_text()
-    match = re.search(r"function updateRoiModule\s*\(i, module\)\s*{[\s\S]*?}\n", html)
-    assert match, 'updateRoiModule function not found'
+    match = re.search(r"function updateRoiGroup\s*\(i, group\)\s*{[\s\S]*?}\n", html)
+    assert match, 'updateRoiGroup function not found'
     func_text = match.group(0)
 
     script = textwrap.dedent(
         f"""
-        let rois = [{{id:'1', module:'old', points:[{{x:1,y:2}}]}}];
+        let rois = [{{id:'1', group:'old', module:'', points:[{{x:1,y:2}}]}}];
         let currentSource = 'src';
         let fetchOpts;
         global.fetch = (url, opts) => {{ fetchOpts = opts; return Promise.resolve({{}}); }};
         {func_text}
-        updateRoiModule(0, 'new');
+        updateRoiGroup(0, 'new');
         console.log(fetchOpts.body);
         """
     )
 
     result = subprocess.run(['node', '-e', script], capture_output=True, text=True, check=True)
     body = json.loads(result.stdout.strip())
-    assert body['rois'][0]['module'] == 'new'
+    assert body['rois'][0]['group'] == 'new'
     assert body['source'] == 'src'


### PR DESCRIPTION
## Summary
- allow entering a group id when defining ROIs and save it to `rois.json`
- show editable group column in ROI list with inference module defaulting to empty
- expose `/groups` endpoint to list available groups

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689bfb9058dc832b8fe154dce6e492ae