### PR TITLE
feat: add inference module selector to ROI list

### DIFF
--- a/templates/roi_selection.html
+++ b/templates/roi_selection.html
@@ -28,6 +28,7 @@
 
         let currentSource = "";
         let groups = [];
+        let modules = [];
         let initialized = false;
         let isStreaming = false;
         let hasStarted = false;
@@ -77,6 +78,19 @@
             } catch (err) {
                 console.error('Failed to load groups', err);
                 groups = [];
+            }
+            renderRoiList();
+        }
+
+        // Load available inference modules from server
+        async function loadModules() {
+            try {
+                const res = await fetch('/inference_modules');
+                if (!res.ok) throw new Error('Bad response');
+                modules = await res.json();
+            } catch (err) {
+                console.error('Failed to load inference modules', err);
+                modules = [];
             }
             renderRoiList();
         }
@@ -357,7 +371,7 @@
             table.className = 'table table-striped table-sm';
             const thead = document.createElement('thead');
             const headerRow = document.createElement('tr');
-            ['ID', 'x', 'y', 'w', 'h', 'Group', 'Delete'].forEach(col => {
+            ['ID', 'x', 'y', 'w', 'h', 'Group', 'Inference Module', 'Delete'].forEach(col => {
                 const th = document.createElement('th');
                 th.textContent = col;
                 headerRow.appendChild(th);
@@ -389,6 +403,24 @@
                 input.addEventListener('change', e => updateRoiGroup(idx, e.target.value));
                 tdGroup.appendChild(input);
                 tr.appendChild(tdGroup);
+
+                const tdModule = document.createElement('td');
+                const select = document.createElement('select');
+                select.className = 'form-select form-select-sm';
+                const blank = document.createElement('option');
+                blank.value = '';
+                blank.textContent = '';
+                select.appendChild(blank);
+                modules.forEach(m => {
+                    const opt = document.createElement('option');
+                    opt.value = m;
+                    opt.textContent = m;
+                    if (r.module === m) opt.selected = true;
+                    select.appendChild(opt);
+                });
+                select.addEventListener('change', e => updateRoiModule(idx, e.target.value));
+                tdModule.appendChild(select);
+                tr.appendChild(tdModule);
 
                 const tdDel = document.createElement('td');
                 const delBtn = document.createElement('button');
@@ -468,6 +500,15 @@
             });
         }
 
+        function updateRoiModule(i, module) {
+            rois[i].module = module;
+            fetch('/save_roi', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ rois: rois, source: currentSource })
+            });
+        }
+
         function deleteRoi(i) {
             if (!confirm('Delete this ROI?')) return;
             rois.splice(i, 1);
@@ -494,6 +535,7 @@
         window.stopStream = stopStream;
         window.clearAllRois = clearAllRois;
         window.updateRoiGroup = updateRoiGroup;
+        window.updateRoiModule = updateRoiModule;
         window.deleteRoi = deleteRoi;
 
         window.addEventListener('beforeunload', () => {
@@ -503,6 +545,7 @@
         (async () => {
             await loadSources();
             await loadGroups();
+            await loadModules();
             await checkStatus();
             if (typeof showAlert === 'function') showAlert('ROI selection ready', 'success');
         })();

--- a/tests/test_roi_selection_update_module.py
+++ b/tests/test_roi_selection_update_module.py
@@ -1,0 +1,29 @@
+import json
+import re
+import subprocess
+import textwrap
+from pathlib import Path
+
+
+def test_update_roi_module_triggers_save():
+    html = Path('templates/roi_selection.html').read_text()
+    match = re.search(r"function updateRoiModule\s*\(i, module\)\s*{[\s\S]*?}\n", html)
+    assert match, 'updateRoiModule function not found'
+    func_text = match.group(0)
+
+    script = textwrap.dedent(
+        f"""
+        let rois = [{{id:'1', group:'g', module:'old', points:[{{x:1,y:2}}]}}];
+        let currentSource = 'src';
+        let fetchOpts;
+        global.fetch = (url, opts) => {{ fetchOpts = opts; return Promise.resolve({{}}); }};
+        {func_text}
+        updateRoiModule(0, 'new');
+        console.log(fetchOpts.body);
+        """
+    )
+
+    result = subprocess.run(['node', '-e', script], capture_output=True, text=True, check=True)
+    body = json.loads(result.stdout.strip())
+    assert body['rois'][0]['module'] == 'new'
+    assert body['source'] == 'src'


### PR DESCRIPTION
## Summary
- allow ROI list to choose inference module for each region
- add test for ROI module update

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689c01931ec8832ba8a516e3109860f3