### PR TITLE
Align width and height inputs on create source page

### DIFF
--- a/templates/create_source.html
+++ b/templates/create_source.html
@@ -13,17 +13,19 @@
         <label for="source" class="form-label">Source:</label>
         <input type="text" id="source" name="source" class="form-control" required>
     </div>
-    <div class="mb-3">
-        <label>
-            <input type="checkbox" id="width-toggle"> Width:
-        </label>
-        <input type="number" id="width" name="width" class="form-control d-inline-block" style="max-width:150px;" disabled>
-    </div>
-    <div class="mb-3">
-        <label>
-            <input type="checkbox" id="height-toggle"> Height:
-        </label>
-        <input type="number" id="height" name="height" class="form-control d-inline-block" style="max-width:150px;" disabled>
+    <div class="mb-3 d-flex gap-3">
+        <div class="d-flex align-items-center">
+            <label class="me-2 mb-0">
+                <input type="checkbox" id="width-toggle"> Width:
+            </label>
+            <input type="number" id="width" name="width" class="form-control" style="max-width:150px;" disabled>
+        </div>
+        <div class="d-flex align-items-center">
+            <label class="me-2 mb-0">
+                <input type="checkbox" id="height-toggle"> Height:
+            </label>
+            <input type="number" id="height" name="height" class="form-control" style="max-width:150px;" disabled>
+        </div>
     </div>
     <button type="submit" class="btn btn-primary">Create</button>
 </form>


### PR DESCRIPTION
## Summary
- Align optional width and height fields on the create source page so they appear on a single row

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689c8e6056b0832b9b8f08db938337a1