### PR TITLE
Respect ROI mode selection when starting video

### DIFF
--- a/templates/roi_selection.html
+++ b/templates/roi_selection.html
@@ -203,7 +203,6 @@
             }
             openSocket();
             await loadRois();
-            setMode('points');
             isStreaming = true;
             stopBtn.disabled = false;
             startBtn.textContent = "Start";


### PR DESCRIPTION
## Summary
- Keep chosen ROI drawing mode when starting the stream

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689c90524140832b92a3d23c62207d11