### PR TITLE
ย้ายการกำหนดบันทึกรูป ROI ไปยังโมดูล inference

### DIFF
--- a/inference_modules/easy_ocr/custom.py
+++ b/inference_modules/easy_ocr/custom.py
@@ -103,11 +103,24 @@ def _run_ocr_async(frame, roi_id, save, source) -> None:
         _save_image_async(str(path), frame)
 
 
-def process(frame, roi_id=None, save: bool = False, source: str = ""):
+def process(
+    frame,
+    roi_id=None,
+    save: bool = False,
+    source: str = "",
+    cam_id: int | None = None,
+):
     """ประมวลผล ROI และเรียก OCR เมื่อเวลาห่างจากครั้งก่อน >= 2 วินาที
     บันทึกรูปภาพแบบไม่บล็อกเมื่อระบุให้บันทึก"""
 
     _configure_logger(source)
+
+    if cam_id is not None:
+        try:
+            import app  # type: ignore
+            app.save_roi_flags[cam_id] = True
+        except Exception:  # pragma: no cover
+            pass
 
     if isinstance(frame, Image.Image) and np is not None:
         frame = cv2.cvtColor(np.array(frame), cv2.COLOR_RGB2BGR)

--- a/inference_modules/typhoon_ocr/custom.py
+++ b/inference_modules/typhoon_ocr/custom.py
@@ -64,11 +64,24 @@ def _save_image_async(path, image):
         logger.exception(f"Failed to save image {path}: {e}")
 
 
-def process(frame, roi_id=None, save=False, source=""):
+def process(
+    frame,
+    roi_id=None,
+    save=False,
+    source="",
+    cam_id: int | None = None,
+):
     """ประมวลผล ROI และเรียก OCR เมื่อเวลาห่างจากครั้งก่อน >= 2 วินาที
     บันทึกรูปภาพแบบไม่บล็อกเมื่อระบุให้บันทึก"""
 
     _configure_logger(source)
+
+    if cam_id is not None:
+        try:
+            import app  # type: ignore
+            app.save_roi_flags[cam_id] = True
+        except Exception:  # pragma: no cover
+            pass
 
     if isinstance(frame, Image.Image) and np is not None:
         frame = cv2.cvtColor(np.array(frame), cv2.COLOR_RGB2BGR)

--- a/inference_modules/yolo/custom.py
+++ b/inference_modules/yolo/custom.py
@@ -64,11 +64,24 @@ def _save_image_async(path, image):
         logger.exception(f"Failed to save image {path}: {e}")
 
 
-def process(frame, roi_id=None, save=False, source=""):
+def process(
+    frame,
+    roi_id=None,
+    save=False,
+    source="",
+    cam_id: int | None = None,
+):
     """ประมวลผล ROI และเรียก OCR เมื่อเวลาห่างจากครั้งก่อน >= 2 วินาที
     บันทึกรูปภาพแบบไม่บล็อกเมื่อระบุให้บันทึก"""
 
     _configure_logger(source)
+
+    if cam_id is not None:
+        try:
+            import app  # type: ignore
+            app.save_roi_flags[cam_id] = True
+        except Exception:  # pragma: no cover
+            pass
 
     if isinstance(frame, Image.Image) and np is not None:
         frame = cv2.cvtColor(np.array(frame), cv2.COLOR_RGB2BGR)

--- a/tests/test_inference_group_switch.py
+++ b/tests/test_inference_group_switch.py
@@ -15,7 +15,7 @@ def test_inference_switches_module_by_group(monkeypatch):
 
     def make_mod(name):
         mod = types.SimpleNamespace()
-        def process(frame, roi_id=None, save=False, source=""):
+        def process(frame, roi_id=None, save=False, source="", cam_id=None):
             calls.append((name, roi_id))
         mod.process = process
         return mod


### PR DESCRIPTION
## สรุป
- ปรับ `run_inference_loop` ให้ตรวจสอบและส่ง `cam_id` ให้โมดูลที่รองรับ
- ตัดการตั้งค่าสถานะ `save_roi_flags` ออกจาก `start_inference`
- เพิ่มการตั้งค่าสถานะบันทึกรูปใน `custom.py` ของแต่ละโมดูลพร้อมรับพารามิเตอร์ `cam_id`

## การทดสอบ
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689caca4f3f4832b80dfbd27ac234578