### PR TITLE
แก้การกู้คืน state เมื่อไม่มี camera config

### DIFF
--- a/app.py
+++ b/app.py
@@ -599,7 +599,11 @@ async def resume_from_state() -> None:
             cam_id = int(cam_id_str)
         except Exception:
             continue
-        cfg = camera_cfgs.get(str(cam_id), {})
+        cfg = camera_cfgs.get(str(cam_id))
+        if not cfg:
+            # หากไม่มีการบันทึก config ของกล้องไว้ ให้ข้ามเพื่อไม่ให้ state เสียหาย
+            print(f"resume warning missing camera settings for cam {cam_id}")
+            continue
         try:
             resp, status = await apply_set_camera(cam_id, cfg)
             if status != 200:


### PR DESCRIPTION
## สรุป
- ป้องกันการเขียน state กล้องเป็นค่าว่างเมื่อไม่มีการบันทึกค่า config
- เพิ่มข้อความเตือนเมื่อไม่พบข้อมูลกล้องใน state

## การทดสอบ
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689d4b10c0a8832bb0e901efc9a28578