### PR TITLE
แก้การกู้คืน state เมื่อไม่มี camera config

### DIFF
--- a/app.py
+++ b/app.py
@@ -50,7 +50,6 @@ ALLOWED_ROI_DIR = os.path.realpath("data_sources")
 async def restore_state():
     state = load_state()
     active_sources.update(state.get("active_sources", {}))
-    active_modules.update(state.get("active_modules", {}))
     inference_started.update(state.get("inference_started", {}))
     for cam_id, source_name in list(active_sources.items()):
         source_dir = os.path.join("data_sources", source_name)
@@ -77,7 +76,7 @@ async def restore_state():
                 )
         else:
             inference_started[cam_id] = False
-    save_state(active_sources, active_modules, inference_started)
+    save_state(active_sources, inference_started)
 
 if hasattr(app, "before_serving"):
     app.before_serving(restore_state)
@@ -392,7 +391,7 @@ async def stop_camera_task(
             gc.collect()
     if task_dict is inference_tasks and status == "stopped":
         inference_started[cam_id] = False
-        save_state(active_sources, active_modules, inference_started)
+        save_state(active_sources, inference_started)
     return task_dict.get(cam_id), {"status": status, "cam_id": cam_id}, 200
 
 
@@ -444,7 +443,7 @@ async def apply_set_camera(cam_id: int, data: dict) -> tuple[dict, int]:
         active_modules[cam_id] = module_name
     else:
         active_modules.pop(cam_id, None)
-    save_state(active_sources, active_modules, inference_started)
+    save_state(active_sources, inference_started)
     source_val = data.get("source", "")
     width_val = data.get("width")
     height_val = data.get("height")
@@ -528,7 +527,7 @@ async def create_source():
     except Exception:
         shutil.rmtree(source_dir, ignore_errors=True)
         return jsonify({"status": "error", "message": "save failed"}), 500
-    save_state(active_sources, active_modules, inference_started)
+    save_state(active_sources, inference_started)
     return jsonify({"status": "created"})
 
 
@@ -579,7 +578,7 @@ async def start_inference(cam_id: int):
     resp, status = await apply_start_inference(cam_id, data)
     if status == 200:
         inference_started[cam_id] = True
-        save_state(active_sources, active_modules, inference_started)
+        save_state(active_sources, inference_started)
     return jsonify(resp), status
 
 
@@ -599,7 +598,11 @@ async def resume_from_state() -> None:
             cam_id = int(cam_id_str)
         except Exception:
             continue
-        cfg = camera_cfgs.get(str(cam_id), {})
+        cfg = camera_cfgs.get(str(cam_id))
+        if not cfg:
+            # หากไม่มีการบันทึก config ของกล้องไว้ ให้ข้ามเพื่อไม่ให้ state เสียหาย
+            print(f"resume warning missing camera settings for cam {cam_id}")
+            continue
         try:
             resp, status = await apply_set_camera(cam_id, cfg)
             if status != 200:
@@ -658,7 +661,8 @@ async def stop_roi_stream(cam_id: int):
 async def inference_status(cam_id: int):
     """คืนค่าความพร้อมของงาน inference"""
     running = inference_tasks.get(cam_id) is not None and not inference_tasks[cam_id].done()
-    return jsonify({"running": running, "cam_id": cam_id})
+    source = active_sources.get(cam_id, "")
+    return jsonify({"running": running, "cam_id": cam_id, "source": source})
 
 
 # ✅ สถานะงาน ROI stream

--- a/state_manager.py
+++ b/state_manager.py
@@ -3,7 +3,7 @@ from pathlib import Path
 from typing import Dict, Any
 
 STATE_FILE = Path(__file__).resolve().parent / "state.json"
-ALLOWED_KEYS = ("active_sources", "active_modules", "inference_started")
+ALLOWED_KEYS = ("active_sources", "inference_started")
 
 
 def load_state() -> Dict[str, Dict[int, Any]]:
@@ -11,7 +11,7 @@ def load_state() -> Dict[str, Dict[int, Any]]:
         with STATE_FILE.open("r", encoding="utf-8") as f:
             data = json.load(f)
     except (FileNotFoundError, json.JSONDecodeError):
-        return {"active_sources": {}, "active_modules": {}, "inference_started": {}}
+        return {"active_sources": {}, "inference_started": {}}
     result: Dict[str, Dict[int, Any]] = {}
     for key in ALLOWED_KEYS:
         raw = data.get(key, {})
@@ -33,9 +33,6 @@ def load_state() -> Dict[str, Dict[int, Any]]:
                         "active_sources": {
                             str(k): v for k, v in result.get("active_sources", {}).items()
                         },
-                        "active_modules": {
-                            str(k): v for k, v in result.get("active_modules", {}).items()
-                        },
                         "inference_started": {
                             str(k): bool(v)
                             for k, v in result.get("inference_started", {}).items()
@@ -50,12 +47,10 @@ def load_state() -> Dict[str, Dict[int, Any]]:
 
 def save_state(
     active_sources: Dict[int, str],
-    active_modules: Dict[int, str],
     inference_started: Dict[int, bool],
 ) -> None:
     data = {
         "active_sources": {str(k): v for k, v in active_sources.items()},
-        "active_modules": {str(k): v for k, v in active_modules.items()},
         "inference_started": {str(k): bool(v) for k, v in inference_started.items()},
     }
     try:

--- a/templates/partials/inference_content.html
+++ b/templates/partials/inference_content.html
@@ -273,9 +273,12 @@
         }
 
         async function checkStatus() {
-            const name = sourceSelect.value;
             const res = await fetchWithStatus(`/inference_status/${cam}`);
             const data = await res.json();
+            if (data.source && !sourceSelect.value) {
+                sourceSelect.value = data.source;
+            }
+            const name = sourceSelect.value;
             if (data.running && name) {
                 openSocket();
                 const cfgRes = await fetchWithStatus(`/source_config?name=${encodeURIComponent(name)}`);


### PR DESCRIPTION
## สรุป
- ป้องกันการเขียน state กล้องเป็นค่าว่างเมื่อไม่มีการบันทึกค่า config
- เพิ่มข้อมูล source ใน `inference_status` และเลือก source อัตโนมัติหลังรีสตาร์ตเพื่อให้ ROI แสดงได้
- ลบฟิลด์ `active_modules` ออกจาก state.json และปรับโค้ดให้จัดการเฉพาะ `active_sources` และ `inference_started`

## การทดสอบ
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689d4b10c0a8832bb0e901efc9a28578