### PR TITLE
feat: default ROI naming and grouping

### DIFF
--- a/templates/partials/inference_content.html
+++ b/templates/partials/inference_content.html
@@ -145,7 +145,8 @@
                 groupSelect.appendChild(opt);
             });
             const stored = selected || localStorage.getItem(`${cellId}-group`) || '';
-            groupSelect.value = stored;
+            groupSelect.value = stored || (groups.includes('main') ? 'main' : '');
+            return groupSelect.value;
         }
 
         async function startInference(roisOverride = null, selectedGroup = '') {
@@ -185,15 +186,17 @@
             const data = await res.json();
             statusEl.innerText = 'Loaded: ' + data.filename;
             allRois = data.rois || [];
+            selectedGroup = loadGroupOptions(allRois, selectedGroup);
             if (selectedGroup) {
                 localStorage.setItem(`${cellId}-group`, selectedGroup);
             } else {
                 localStorage.removeItem(`${cellId}-group`);
             }
-            loadGroupOptions(allRois, selectedGroup);
-            rois = roisOverride || (selectedGroup && selectedGroup !== 'all'
-                ? allRois.filter(r => r.group === selectedGroup)
-                : selectedGroup === 'all' ? allRois : []);
+            rois = roisOverride || (selectedGroup === 'all'
+                ? allRois
+                : selectedGroup
+                    ? allRois.filter(r => r.group === selectedGroup)
+                    : []);
             if (rois.length > 0) {
                 renderRoiPlaceholders();
             } else {
@@ -287,9 +290,12 @@
                 const roiRes = await fetchWithStatus(`/load_roi_file?path=${encodeURIComponent(roiPath)}`);
                 const roiData = await roiRes.json();
                 allRois = roiData.rois || [];
-                loadGroupOptions(allRois);
-                const stored = groupSelect.value;
-                rois = stored === 'all' ? allRois : stored ? allRois.filter(r => r.group === stored) : [];
+                const stored = loadGroupOptions(allRois);
+                rois = stored === 'all'
+                    ? allRois
+                    : stored
+                        ? allRois.filter(r => r.group === stored)
+                        : [];
                 if (rois.length > 0) {
                     renderRoiPlaceholders();
                     openRoiSocket();
@@ -309,9 +315,8 @@
             const selected = groupSelect.value;
             if (!selected) return;
             localStorage.setItem(`${cellId}-group`, selected);
-            const filtered = selected === 'all' ? allRois : allRois.filter(r => r.group === selected);
             await stopInference();
-            await startInference(filtered, selected);
+            await startInference(null, selected);
         }
 
         function setRunningUI() {

--- a/templates/roi_selection.html
+++ b/templates/roi_selection.html
@@ -234,22 +234,20 @@
             if (currentMode === 'points') {
                 currentPoints.push({ x, y });
                 if (currentPoints.length === 4) {
-                    const roiId = prompt("ROI id?");
-                    if (roiId !== null) {
-                        const groupId = prompt("Group id?");
-                        rois.push({
-                            id: roiId,
-                            group: groupId,
-                            module: "",
-                            points: currentPoints.slice()
-                        });
-                        renderRoiList();
-                        fetch('/save_roi', {
-                            method: 'POST',
-                            headers: { 'Content-Type': 'application/json' },
-                            body: JSON.stringify({ rois: rois, source: currentSource })
-                        });
-                    }
+                    const roiId = `roi_${Date.now()}`;
+                    const groupId = 'main';
+                    rois.push({
+                        id: roiId,
+                        group: groupId,
+                        module: "",
+                        points: currentPoints.slice()
+                    });
+                    renderRoiList();
+                    fetch('/save_roi', {
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify({ rois: rois, source: currentSource })
+                    });
                     currentPoints = [];
                 }
             } else if (currentMode === 'rect') {
@@ -268,17 +266,15 @@
                         { x: x2, y: y2 },
                         { x: x1, y: y2 }
                     ];
-                    const roiId = prompt("ROI id?");
-                    if (roiId !== null) {
-                        const groupId = prompt("Group id?");
-                        rois.push({ id: roiId, group: groupId, module: "", points });
-                        renderRoiList();
-                        fetch('/save_roi', {
-                            method: 'POST',
-                            headers: { 'Content-Type': 'application/json' },
-                            body: JSON.stringify({ rois: rois, source: currentSource })
-                        });
-                    }
+                    const roiId = `roi_${Date.now()}`;
+                    const groupId = 'main';
+                    rois.push({ id: roiId, group: groupId, module: "", points });
+                    renderRoiList();
+                    fetch('/save_roi', {
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify({ rois: rois, source: currentSource })
+                    });
                     rectStart = null;
                     rectEnd = null;
                     drawingRect = false;

--- a/tests/test_roi_selection_click_polygon.py
+++ b/tests/test_roi_selection_click_polygon.py
@@ -21,11 +21,7 @@ def test_click_creates_polygon_and_saves():
     let fetchBody;
     function renderRoiList(){}
     function drawAllRois(){}
-    global.prompt = (msg) => {
-        if (msg === 'ROI id?') return '1';
-        if (msg === 'Group id?') return 'g1';
-        return null;
-    };
+    Date.now = () => 123;
     global.fetch = (url, opts) => { fetchBody = opts.body; return Promise.resolve({}); };
     const frameContainer = { getBoundingClientRect: () => ({left:0, top:0, width:100, height:100}) };
     const canvas = { width:100, height:100 };
@@ -47,9 +43,11 @@ def test_click_creates_polygon_and_saves():
     assert pts[1] == {'x': 50, 'y': 10}
     assert pts[2] == {'x': 50, 'y': 50}
     assert pts[3] == {'x': 10, 'y': 50}
-    assert data['rois'][0]['group'] == 'g1'
+    assert data['rois'][0]['id'] == 'roi_123'
+    assert data['rois'][0]['group'] == 'main'
     assert data['rois'][0]['module'] == ''
     payload = json.loads(data['fetchBody'])
     assert payload['rois'][0]['points'] == pts
-    assert payload['rois'][0]['group'] == 'g1'
+    assert payload['rois'][0]['id'] == 'roi_123'
+    assert payload['rois'][0]['group'] == 'main'
     assert payload['rois'][0]['module'] == ''

--- a/tests/test_roi_selection_click_rect.py
+++ b/tests/test_roi_selection_click_rect.py
@@ -20,11 +20,7 @@ def test_click_creates_rectangle_and_saves():
     let fetchBody;
     function renderRoiList(){}
     function drawAllRois(){}
-    global.prompt = (msg) => {
-        if (msg === 'ROI id?') return '1';
-        if (msg === 'Group id?') return 'g1';
-        return null;
-    };
+    Date.now = () => 123;
     global.fetch = (url, opts) => { fetchBody = opts.body; return Promise.resolve({}); };
     const frameContainer = { getBoundingClientRect: () => ({left:0, top:0, width:100, height:100}) };
     const canvas = { width:100, height:100 };
@@ -44,9 +40,11 @@ def test_click_creates_rectangle_and_saves():
     assert pts[1] == {'x': 50, 'y': 20}
     assert pts[2] == {'x': 50, 'y': 60}
     assert pts[3] == {'x': 10, 'y': 60}
-    assert data['rois'][0]['group'] == 'g1'
+    assert data['rois'][0]['id'] == 'roi_123'
+    assert data['rois'][0]['group'] == 'main'
     assert data['rois'][0]['module'] == ''
     payload = json.loads(data['fetchBody'])
     assert payload['rois'][0]['points'] == pts
-    assert payload['rois'][0]['group'] == 'g1'
+    assert payload['rois'][0]['id'] == 'roi_123'
+    assert payload['rois'][0]['group'] == 'main'
     assert payload['rois'][0]['module'] == ''


### PR DESCRIPTION
## Summary
- auto-generate ROI IDs using timestamps
- default new ROIs to the `main` group
- auto-select the `main` group on the inference page
- reload ROIs when switching groups to show newly added items

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689d53d681f0832b920ac09cdc080f91