### PR TITLE
Persist inference state across restarts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -217,3 +217,6 @@ rois_*.json
 # macOS metadata
 .DS_Store
 */.DS_Store
+
+# Service state
+service_state.json


### PR DESCRIPTION
## Summary
- persist active camera and inference state to disk
- restore previous inference tasks on service startup
- ensure camera updates and stop actions save state
- ignore generated service_state.json file

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689d5c02e7d4832ba28f3b8fdb919501