### PR TITLE
แก้บั๊กการเลือกกลุ่ม ROI หลังรีสตาร์ท

### DIFF
--- a/templates/partials/inference_content.html
+++ b/templates/partials/inference_content.html
@@ -290,6 +290,11 @@
                 loadGroupOptions(allRois);
                 const stored = groupSelect.value;
                 rois = stored === 'all' ? allRois : stored ? allRois.filter(r => r.group === stored) : [];
+                await fetchWithStatus(`/start_inference/${cam}`, {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ rois })
+                });
                 if (rois.length > 0) {
                     renderRoiPlaceholders();
                     openRoiSocket();


### PR DESCRIPTION
## สรุป
- เรียก API `start_inference` พร้อมค่า ROI ของกลุ่มที่เลือกเมื่อโหลดหน้าตรวจสอบสถานะ
- ปรับให้เฟรม ROI ในวิดีโอตรงกับกลุ่มที่เลือกหลังรีสตาร์ท

## การทดสอบ
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689d685a2f1c832bbaf12ee5f0965b1b