### PR TITLE
Remove source-level inference module config

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,12 +160,11 @@ tg.start_send_text("สวัสดี")
 
 ## API/Endpoints
 
-- **POST `/start_inference/<cam_id>`** – เริ่มอ่านภาพและประมวลผล ROI ที่ส่งมา (หากไม่ส่ง `rois` จะโหลดจากไฟล์ของ source) พร้อมตั้งค่ากล้องจากข้อมูลใน body (`name`, `source`, `width`, `height`, `module`)
+- **POST `/start_inference/<cam_id>`** – เริ่มอ่านภาพและประมวลผล ROI ที่ส่งมา (หากไม่ส่ง `rois` จะโหลดจากไฟล์ของ source) พร้อมตั้งค่ากล้องจากข้อมูลใน body (`name`, `source`, `width`, `height`)
   ```json
   {
     "name": "cam1",
     "source": "0",
-    "module": "yolo",
     "rois": [
       {
         "id": "1",
@@ -269,6 +268,7 @@ data_sources/
 ```
 
 แต่ละ ROI สามารถกำหนด `group` สำหรับเลือก group id ได้ ส่วนค่า `module` จะเริ่มต้นเป็นค่าว่าง
+หากเว้นว่างจะไม่ประมวลผล ROI นั้น
 
 โมดูลสำหรับประมวลผลจะเก็บไว้ในโฟลเดอร์ `inference_modules/<module_name>/custom.py`
 

--- a/templates/partials/inference_content.html
+++ b/templates/partials/inference_content.html
@@ -163,7 +163,7 @@
             const cfgRes = await fetchWithStatus(`/source_config?name=${encodeURIComponent(name)}`);
             const cfg = await cfgRes.json();
 
-            const { rois: roiPathRaw, ...camCfg } = cfg;
+            const { module: _unused, rois: roiPathRaw, ...camCfg } = cfg;
             let roiPath = roiPathRaw;
             if (!roiPath.startsWith('/')) {
                 roiPath = `data_sources/${cfg.name}/${roiPath}`;

--- a/templates/roi_selection.html
+++ b/templates/roi_selection.html
@@ -180,11 +180,11 @@
             startBtn.disabled = true;
             currentSource = name;
             const cfg = await fetch(`/source_config?name=${encodeURIComponent(name)}`).then(r => r.json());
-            const { module, rois, ...cfgNoModule } = cfg;
+            const { rois, ...camCfg } = cfg;
             const startRes = await fetch(`/start_roi_stream/${cam}`, {
                 method: "POST",
                 headers: { "Content-Type": "application/json" },
-                body: JSON.stringify(cfgNoModule)
+                body: JSON.stringify(camCfg)
             });
             if (!startRes.ok) {
                 if (typeof showAlert === 'function') showAlert('Failed to start ROI stream', 'error');

--- a/tests/test_inference_group_switch.py
+++ b/tests/test_inference_group_switch.py
@@ -78,7 +78,6 @@ def test_inference_switches_module_by_group(monkeypatch):
     monkeypatch.setattr(app, "read_and_queue_frame", fake_read_and_queue_frame)
 
     app.inference_rois[0] = rois_group1
-    app.active_modules[0] = ""
     app.save_roi_flags[0] = False
 
     asyncio.run(app.run_inference_loop(0))


### PR DESCRIPTION
## Summary
- drop source-level module settings and rely on ROI modules only
- skip ROIs without an inference module
- update ROI and inference templates and docs accordingly

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689d761908a8832b98785209a96e2ecb