### PR TITLE
feat: preview rectangle for page roi

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -153,5 +153,4 @@ button.delete {
   left: 0;
   top: 0;
   z-index: 1;
-  pointer-events: none;
 }

--- a/templates/create_page.html
+++ b/templates/create_page.html
@@ -24,6 +24,8 @@
   let socket;
   let rois = [];
   let currentPoints = [];
+  let previewRect = null;
+  let hoverPoint = null;
   let initialized = false;
   let currentSource = "";
   const cam = 1;
@@ -58,7 +60,10 @@
     const x = Math.round(e.clientX - rect.left);
     const y = Math.round(e.clientY - rect.top);
     currentPoints.push({x, y});
-    if (currentPoints.length === 2) {
+    if (currentPoints.length === 1) {
+      previewRect = { x, y, width: 0, height: 0 };
+      drawAll();
+    } else if (currentPoints.length === 2) {
       const x1 = Math.min(currentPoints[0].x, currentPoints[1].x);
       const y1 = Math.min(currentPoints[0].y, currentPoints[1].y);
       const x2 = Math.max(currentPoints[0].x, currentPoints[1].x);
@@ -71,9 +76,32 @@
         height: y2 - y1
       });
       currentPoints = [];
+      previewRect = null;
       drawAll();
       renderTable();
     }
+  });
+
+  canvas.addEventListener('mousemove', (e) => {
+    const rect = canvas.getBoundingClientRect();
+    const x = Math.round(e.clientX - rect.left);
+    const y = Math.round(e.clientY - rect.top);
+    if (currentPoints.length === 1) {
+      const x1 = Math.min(currentPoints[0].x, x);
+      const y1 = Math.min(currentPoints[0].y, y);
+      const x2 = Math.max(currentPoints[0].x, x);
+      const y2 = Math.max(currentPoints[0].y, y);
+      previewRect = { x: x1, y: y1, width: x2 - x1, height: y2 - y1 };
+      hoverPoint = null;
+    } else {
+      hoverPoint = { x, y };
+    }
+    drawAll();
+  });
+
+  canvas.addEventListener('mouseleave', () => {
+    hoverPoint = null;
+    drawAll();
   });
 
   function drawAll(){
@@ -83,6 +111,17 @@
     rois.forEach(r => {
       ctx.strokeRect(r.x, r.y, r.width, r.height);
     });
+    if (hoverPoint && currentPoints.length === 0 && currentSource) {
+      ctx.fillStyle = 'red';
+      ctx.beginPath();
+      ctx.arc(hoverPoint.x, hoverPoint.y, 3, 0, Math.PI * 2);
+      ctx.fill();
+    }
+    if (previewRect) {
+      ctx.setLineDash([5, 3]);
+      ctx.strokeRect(previewRect.x, previewRect.y, previewRect.width, previewRect.height);
+      ctx.setLineDash([]);
+    }
   }
 
   function renderTable(){


### PR DESCRIPTION
## Summary
- show rectangle preview while selecting page ROI before finalizing
- draw red cursor dot and enable ROI selection

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689de862a4a8832bace020728e6b1d17