### PR TITLE
Add page ROI listing with crop capability

### DIFF
--- a/templates/roi_selection.html
+++ b/templates/roi_selection.html
@@ -12,6 +12,7 @@
     <div id="roiToolbar" class="btn-group-vertical me-2">
         <button id="pickBtn" class="btn btn-primary">Pick Points</button>
         <button id="rectBtn" class="btn btn-secondary">Rectangle</button>
+        <button id="pageBtn" class="btn btn-secondary">Page Rect</button>
     </div>
     <div id="frameContainer" style="position: relative; display: inline-block;">
         <img id="video" />
@@ -25,6 +26,7 @@
     (function() {
         let socket;
         let rois = [];
+        let pageRois = [];
         let otherRois = [];
         let currentPoints = [];
         let hoverPoint = null;
@@ -33,6 +35,7 @@
         let rectEnd = null;
         let drawingRect = false;
         let currentMode = 'points';
+        let currentType = 'roi';
 
         let currentSource = "";
         let groups = [];
@@ -50,17 +53,29 @@
         const stopBtn = document.getElementById("stopBtn");
         const pickBtn = document.getElementById("pickBtn");
         const rectBtn = document.getElementById("rectBtn");
-
-        function setMode(mode) {
+        const pageBtn = document.getElementById("pageBtn");
+        function setMode(mode, type = 'roi') {
             currentMode = mode;
+            currentType = type;
             if (mode === 'points') {
                 pickBtn.classList.add('btn-primary');
                 pickBtn.classList.remove('btn-secondary');
                 rectBtn.classList.add('btn-secondary');
                 rectBtn.classList.remove('btn-primary');
+                pageBtn.classList.add('btn-secondary');
+                pageBtn.classList.remove('btn-primary');
+            } else if (type === 'page') {
+                pageBtn.classList.add('btn-primary');
+                pageBtn.classList.remove('btn-secondary');
+                rectBtn.classList.add('btn-secondary');
+                rectBtn.classList.remove('btn-primary');
+                pickBtn.classList.add('btn-secondary');
+                pickBtn.classList.remove('btn-primary');
             } else {
                 rectBtn.classList.add('btn-primary');
                 rectBtn.classList.remove('btn-secondary');
+                pageBtn.classList.add('btn-secondary');
+                pageBtn.classList.remove('btn-primary');
                 pickBtn.classList.add('btn-secondary');
                 pickBtn.classList.remove('btn-primary');
             }
@@ -73,7 +88,8 @@
         }
 
         pickBtn.addEventListener('click', () => setMode('points'));
-        rectBtn.addEventListener('click', () => setMode('rect'));
+        rectBtn.addEventListener('click', () => setMode('rect', 'roi'));
+        pageBtn.addEventListener('click', () => setMode('rect', 'page'));
 
         video.onload = () => {
             if (!initialized || canvas.width !== video.naturalWidth || canvas.height !== video.naturalHeight) {
@@ -240,7 +256,7 @@
                     fetch('/save_roi', {
                         method: 'POST',
                         headers: { 'Content-Type': 'application/json' },
-                        body: JSON.stringify({ rois: rois.concat(typeof otherRois !== 'undefined' ? otherRois : []), source: currentSource })
+                        body: JSON.stringify({ rois: rois.concat(pageRois).concat(typeof otherRois !== 'undefined' ? otherRois : []), source: currentSource })
                     });
                     currentPoints = [];
                 }
@@ -262,12 +278,16 @@
                     ];
                     const roiId = `roi_${Date.now()}`;
                     const groupId = 'main';
-                    rois.push({ id: roiId, group: groupId, module: "", points, type: 'roi' });
+                    if (currentType === 'page') {
+                        pageRois.push({ id: roiId, points, type: 'page', page: '', image: null });
+                    } else {
+                        rois.push({ id: roiId, group: groupId, module: "", points, type: 'roi' });
+                    }
                     renderRoiList();
                     fetch('/save_roi', {
                         method: 'POST',
                         headers: { 'Content-Type': 'application/json' },
-                        body: JSON.stringify({ rois: rois.concat(typeof otherRois !== 'undefined' ? otherRois : []), source: currentSource })
+                        body: JSON.stringify({ rois: rois.concat(pageRois).concat(typeof otherRois !== 'undefined' ? otherRois : []), source: currentSource })
                     });
                     rectStart = null;
                     rectEnd = null;
@@ -307,6 +327,29 @@
 
         function drawAllRois() {
             ctx.clearRect(0, 0, canvas.width, canvas.height);
+            pageRois.forEach(r => {
+                if (!r.points || r.points.length === 0) return;
+                ctx.beginPath();
+                ctx.moveTo(r.points[0].x, r.points[0].y);
+                for (let i = 1; i < r.points.length; i++) {
+                    ctx.lineTo(r.points[i].x, r.points[i].y);
+                }
+                ctx.closePath();
+                ctx.strokeStyle = 'green';
+                ctx.lineWidth = 2;
+                ctx.stroke();
+                r.points.forEach(p => {
+                    ctx.beginPath();
+                    ctx.arc(p.x, p.y, 5, 0, 2 * Math.PI);
+                    ctx.fillStyle = 'green';
+                    ctx.fill();
+                });
+                if (r.id !== undefined) {
+                    ctx.font = '16px sans-serif';
+                    ctx.fillStyle = 'green';
+                    ctx.fillText(r.id, r.points[0].x, Math.max(10, r.points[0].y - 5));
+                }
+            });
             rois.forEach(r => {
                 if (!r.points || r.points.length === 0) return;
                 ctx.beginPath();
@@ -381,75 +424,140 @@
             if (!container) return;
             container.innerHTML = '';
 
-            if (rois.length === 0) return;
-
-            const table = document.createElement('table');
-            table.className = 'table table-striped table-sm';
-            const thead = document.createElement('thead');
-            const headerRow = document.createElement('tr');
-            ['ID', 'x', 'y', 'w', 'h', 'Group', 'Inference Module', 'Delete'].forEach(col => {
-                const th = document.createElement('th');
-                th.textContent = col;
-                headerRow.appendChild(th);
-            });
-            thead.appendChild(headerRow);
-            table.appendChild(thead);
-
-            const tbody = document.createElement('tbody');
-            rois.forEach((r, idx) => {
-                const xs = r.points.map(p => p.x);
-                const ys = r.points.map(p => p.y);
-                const x = Math.min(...xs);
-                const y = Math.min(...ys);
-                const w = Math.max(...xs) - x;
-                const h = Math.max(...ys) - y;
-                const tr = document.createElement('tr');
-                const idTd = document.createElement('td');
-                idTd.textContent = r.id;
-                tr.appendChild(idTd);
-                [x, y, w, h].forEach(val => {
-                    const td = document.createElement('td');
-                    td.textContent = Math.round(val);
-                    tr.appendChild(td);
+            if (rois.length > 0) {
+                const table = document.createElement('table');
+                table.className = 'table table-striped table-sm';
+                const thead = document.createElement('thead');
+                const headerRow = document.createElement('tr');
+                ['ID', 'x', 'y', 'w', 'h', 'Group', 'Inference Module', 'Delete'].forEach(col => {
+                    const th = document.createElement('th');
+                    th.textContent = col;
+                    headerRow.appendChild(th);
                 });
-                const tdGroup = document.createElement('td');
-                const input = document.createElement('input');
-                input.className = 'form-control form-control-sm';
-                input.value = r.group || '';
-                input.addEventListener('change', e => updateRoiGroup(idx, e.target.value));
-                tdGroup.appendChild(input);
-                tr.appendChild(tdGroup);
+                thead.appendChild(headerRow);
+                table.appendChild(thead);
 
-                const tdModule = document.createElement('td');
-                const select = document.createElement('select');
-                select.className = 'form-select form-select-sm';
-                const blank = document.createElement('option');
-                blank.value = '';
-                blank.textContent = '';
-                select.appendChild(blank);
-                modules.forEach(m => {
-                    const opt = document.createElement('option');
-                    opt.value = m;
-                    opt.textContent = m;
-                    if (r.module === m) opt.selected = true;
-                    select.appendChild(opt);
+                const tbody = document.createElement('tbody');
+                rois.forEach((r, idx) => {
+                    const xs = r.points.map(p => p.x);
+                    const ys = r.points.map(p => p.y);
+                    const x = Math.min(...xs);
+                    const y = Math.min(...ys);
+                    const w = Math.max(...xs) - x;
+                    const h = Math.max(...ys) - y;
+                    const tr = document.createElement('tr');
+                    const idTd = document.createElement('td');
+                    idTd.textContent = r.id;
+                    tr.appendChild(idTd);
+                    [x, y, w, h].forEach(val => {
+                        const td = document.createElement('td');
+                        td.textContent = Math.round(val);
+                        tr.appendChild(td);
+                    });
+                    const tdGroup = document.createElement('td');
+                    const input = document.createElement('input');
+                    input.className = 'form-control form-control-sm';
+                    input.value = r.group || '';
+                    input.addEventListener('change', e => updateRoiGroup(idx, e.target.value));
+                    tdGroup.appendChild(input);
+                    tr.appendChild(tdGroup);
+
+                    const tdModule = document.createElement('td');
+                    const select = document.createElement('select');
+                    select.className = 'form-select form-select-sm';
+                    const blank = document.createElement('option');
+                    blank.value = '';
+                    blank.textContent = '';
+                    select.appendChild(blank);
+                    modules.forEach(m => {
+                        const opt = document.createElement('option');
+                        opt.value = m;
+                        opt.textContent = m;
+                        if (r.module === m) opt.selected = true;
+                        select.appendChild(opt);
+                    });
+                    select.addEventListener('change', e => updateRoiModule(idx, e.target.value));
+                    tdModule.appendChild(select);
+                    tr.appendChild(tdModule);
+
+                    const tdDel = document.createElement('td');
+                    const delBtn = document.createElement('button');
+                    delBtn.textContent = 'Delete';
+                    delBtn.className = 'btn btn-danger btn-sm';
+                    delBtn.addEventListener('click', () => deleteRoi(idx));
+                    tdDel.appendChild(delBtn);
+                    tr.appendChild(tdDel);
+                    tbody.appendChild(tr);
                 });
-                select.addEventListener('change', e => updateRoiModule(idx, e.target.value));
-                tdModule.appendChild(select);
-                tr.appendChild(tdModule);
 
-                const tdDel = document.createElement('td');
-                const delBtn = document.createElement('button');
-                delBtn.textContent = 'Delete';
-                delBtn.className = 'btn btn-danger btn-sm';
-                delBtn.addEventListener('click', () => deleteRoi(idx));
-                tdDel.appendChild(delBtn);
-                tr.appendChild(tdDel);
-                tbody.appendChild(tr);
-            });
+                table.appendChild(tbody);
+                container.appendChild(table);
+            }
 
-            table.appendChild(tbody);
-            container.appendChild(table);
+            if (pageRois.length > 0) {
+                const table = document.createElement('table');
+                table.className = 'table table-striped table-sm mt-3';
+                const thead = document.createElement('thead');
+                const headerRow = document.createElement('tr');
+                ['ID', 'x', 'y', 'w', 'h', 'Page', 'Crop Image', 'Action'].forEach(col => {
+                    const th = document.createElement('th');
+                    th.textContent = col;
+                    headerRow.appendChild(th);
+                });
+                thead.appendChild(headerRow);
+                table.appendChild(thead);
+
+                const tbody = document.createElement('tbody');
+                pageRois.forEach((r, idx) => {
+                    const xs = r.points.map(p => p.x);
+                    const ys = r.points.map(p => p.y);
+                    const x = Math.min(...xs);
+                    const y = Math.min(...ys);
+                    const w = Math.max(...xs) - x;
+                    const h = Math.max(...ys) - y;
+                    const tr = document.createElement('tr');
+                    const idTd = document.createElement('td');
+                    idTd.textContent = r.id;
+                    tr.appendChild(idTd);
+                    [x, y, w, h].forEach(val => {
+                        const td = document.createElement('td');
+                        td.textContent = Math.round(val);
+                        tr.appendChild(td);
+                    });
+                    const tdPage = document.createElement('td');
+                    const input = document.createElement('input');
+                    input.className = 'form-control form-control-sm';
+                    input.id = `page_${idx}`;
+                    input.value = r.page || '';
+                    if (r.image) input.disabled = true;
+                    tdPage.appendChild(input);
+                    tr.appendChild(tdPage);
+
+                    const imgTd = document.createElement('td');
+                    if (r.image) {
+                        const img = document.createElement('img');
+                        img.src = `data:image/jpeg;base64,${r.image}`;
+                        img.style.maxWidth = '100px';
+                        imgTd.appendChild(img);
+                    }
+                    tr.appendChild(imgTd);
+
+                    const actionTd = document.createElement('td');
+                    if (!r.image) {
+                        const btn = document.createElement('button');
+                        btn.textContent = 'Crop';
+                        btn.className = 'btn btn-primary btn-sm';
+                        btn.addEventListener('click', () => cropPageRoi(idx));
+                        actionTd.appendChild(btn);
+                    }
+                    tr.appendChild(actionTd);
+
+                    tbody.appendChild(tr);
+                });
+
+                table.appendChild(tbody);
+                container.appendChild(table);
+            }
         }
 
         async function loadRois() {
@@ -461,7 +569,27 @@
             }
             const res = await fetch(`/load_roi/${encodeURIComponent(currentSource)}`);
             const data = await res.json();
-            otherRois = data.rois.filter(r => (r.type ?? 'roi') !== 'roi');
+            otherRois = data.rois.filter(r => !['roi', 'page'].includes(r.type ?? 'roi'));
+            pageRois = data.rois
+                .filter(r => (r.type ?? 'roi') === 'page')
+                .map((r, idx) => {
+                    let pts = r.points;
+                    if (!pts && "x" in r && "y" in r && "width" in r && "height" in r) {
+                        pts = [
+                            { x: r.x, y: r.y },
+                            { x: r.x + r.width, y: r.y },
+                            { x: r.x + r.width, y: r.y + r.height },
+                            { x: r.x, y: r.y + r.height }
+                        ];
+                    }
+                    return {
+                        id: r.id ?? String(idx + 1),
+                        page: r.page ?? r.name ?? '',
+                        image: r.image ?? null,
+                        points: pts || [],
+                        type: 'page'
+                    };
+                });
             rois = data.rois
                 .filter(r => (r.type ?? 'roi') === 'roi')
                 .map((r, idx) => {
@@ -488,13 +616,14 @@
         }
 
         function clearAllRois() {
-            if (rois.length === 0) {
+            if (rois.length === 0 && pageRois.length === 0) {
                 if (typeof showAlert === 'function') showAlert('No ROI to clear', 'error');
                 return;
             }
             if (!confirm("Clear all ROIs?")) return;
 
             rois = [];
+            pageRois = [];
             currentPoints = [];
             drawAllRois();
             renderRoiList();
@@ -502,7 +631,7 @@
             fetch(`/save_roi`, {
                 method: "POST",
                 headers: { "Content-Type": "application/json" },
-                body: JSON.stringify({ rois: rois.concat(typeof otherRois !== 'undefined' ? otherRois : []), source: currentSource })
+                body: JSON.stringify({ rois: rois.concat(pageRois).concat(typeof otherRois !== 'undefined' ? otherRois : []), source: currentSource })
             })
             .then(res => res.json())
             .then(data => {
@@ -516,7 +645,7 @@
             fetch('/save_roi', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ rois: rois.concat(typeof otherRois !== 'undefined' ? otherRois : []), source: currentSource })
+                body: JSON.stringify({ rois: rois.concat(pageRois).concat(typeof otherRois !== 'undefined' ? otherRois : []), source: currentSource })
             });
         }
 
@@ -525,7 +654,7 @@
             fetch('/save_roi', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ rois: rois.concat(typeof otherRois !== 'undefined' ? otherRois : []), source: currentSource })
+                body: JSON.stringify({ rois: rois.concat(pageRois).concat(typeof otherRois !== 'undefined' ? otherRois : []), source: currentSource })
             });
         }
 
@@ -538,13 +667,54 @@
             fetch(`/save_roi`, {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ rois: rois.concat(typeof otherRois !== 'undefined' ? otherRois : []), source: currentSource })
+                body: JSON.stringify({ rois: rois.concat(pageRois).concat(typeof otherRois !== 'undefined' ? otherRois : []), source: currentSource })
             })
             .then(res => res.json())
             .then(data => {
                 if (typeof showAlert === 'function') showAlert('Deleted. Saved to: ' + data.filename, 'success');
             });
 
+        }
+
+        async function cropPageRoi(i) {
+            const nameInput = document.getElementById(`page_${i}`);
+            const pageName = nameInput.value.trim();
+            if (!pageName) {
+                if (typeof showAlert === 'function') showAlert('Enter page name', 'error');
+                return;
+            }
+            const r = pageRois[i];
+            const xs = r.points.map(p => p.x);
+            const ys = r.points.map(p => p.y);
+            const x = Math.min(...xs);
+            const y = Math.min(...ys);
+            const w = Math.max(...xs) - x;
+            const h = Math.max(...ys) - y;
+
+            const img = document.getElementById('video');
+            const tmp = document.createElement('canvas');
+            tmp.width = img.naturalWidth;
+            tmp.height = img.naturalHeight;
+            const tctx = tmp.getContext('2d');
+            tctx.drawImage(img, 0, 0);
+            const crop = document.createElement('canvas');
+            crop.width = w;
+            crop.height = h;
+            const cctx = crop.getContext('2d');
+            cctx.drawImage(tmp, x, y, w, h, 0, 0, w, h);
+            const base64 = crop.toDataURL('image/jpeg').split(',')[1];
+
+            r.page = pageName;
+            r.image = base64;
+
+            await fetch('/save_roi', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ rois: rois.concat(pageRois).concat(typeof otherRois !== 'undefined' ? otherRois : []), source: currentSource })
+            });
+
+            renderRoiList();
+            if (typeof showAlert === 'function') showAlert('Cropped and saved', 'success');
         }
 
         startBtn.addEventListener('click', startStream);

--- a/tests/test_roi_selection_click_page_rect.py
+++ b/tests/test_roi_selection_click_page_rect.py
@@ -5,7 +5,7 @@ import textwrap
 from pathlib import Path
 
 
-def test_click_creates_rectangle_and_saves():
+def test_click_creates_page_rect_and_saves():
     html = Path('templates/roi_selection.html').read_text()
     match = re.search(r"frameContainer.addEventListener\('click',\s*\(e\) => \{([\s\S]*?drawAllRois\(\);\n\s*)\}\);", html)
     assert match, 'click handler not found'
@@ -18,7 +18,7 @@ def test_click_creates_rectangle_and_saves():
     let rectStart = null, rectEnd = null, drawingRect = false;
     let currentPoints = [];
     let currentMode = 'rect';
-    let currentType = 'roi';
+    let currentType = 'page';
     let currentSource = 'src';
     let fetchBody;
     function renderRoiList(){}
@@ -32,22 +32,21 @@ def test_click_creates_rectangle_and_saves():
     }
     handler({clientX:10, clientY:20});
     handler({clientX:50, clientY:60});
-    console.log(JSON.stringify({rois, fetchBody}));
+    console.log(JSON.stringify({pageRois, fetchBody}));
     """).replace('{handler}', handler)
 
     result = subprocess.run(['node', '-e', script], capture_output=True, text=True, check=True)
     data = json.loads(result.stdout.strip())
-    assert len(data['rois']) == 1
-    pts = data['rois'][0]['points']
+    assert len(data['pageRois']) == 1
+    pts = data['pageRois'][0]['points']
     assert pts[0] == {'x': 10, 'y': 20}
     assert pts[1] == {'x': 50, 'y': 20}
     assert pts[2] == {'x': 50, 'y': 60}
     assert pts[3] == {'x': 10, 'y': 60}
-    assert data['rois'][0]['id'] == 'roi_123'
-    assert data['rois'][0]['group'] == 'main'
-    assert data['rois'][0]['module'] == ''
+    assert data['pageRois'][0]['id'] == 'roi_123'
+    assert data['pageRois'][0]['page'] == ''
+    assert data['pageRois'][0]['image'] is None
     payload = json.loads(data['fetchBody'])
     assert payload['rois'][0]['points'] == pts
     assert payload['rois'][0]['id'] == 'roi_123'
-    assert payload['rois'][0]['group'] == 'main'
-    assert payload['rois'][0]['module'] == ''
+    assert payload['rois'][0]['type'] == 'page'

--- a/tests/test_roi_selection_click_polygon.py
+++ b/tests/test_roi_selection_click_polygon.py
@@ -13,9 +13,12 @@ def test_click_creates_polygon_and_saves():
 
     script = textwrap.dedent("""
     let rois = [];
+    let pageRois = [];
+    let otherRois = [];
     let currentPoints = [];
     let drawingRect = false;
     let currentMode = 'points';
+    let currentType = 'roi';
     let rectStart = null, rectEnd = null;
     let currentSource = 'src';
     let fetchBody;

--- a/tests/test_roi_selection_update_group.py
+++ b/tests/test_roi_selection_update_group.py
@@ -14,6 +14,8 @@ def test_update_roi_group_triggers_save():
     script = textwrap.dedent(
         f"""
         let rois = [{{id:'1', group:'old', module:'', points:[{{x:1,y:2}}]}}];
+        let pageRois = [];
+        let otherRois = [];
         let currentSource = 'src';
         let fetchOpts;
         global.fetch = (url, opts) => {{ fetchOpts = opts; return Promise.resolve({{}}); }};

--- a/tests/test_roi_selection_update_module.py
+++ b/tests/test_roi_selection_update_module.py
@@ -14,6 +14,8 @@ def test_update_roi_module_triggers_save():
     script = textwrap.dedent(
         f"""
         let rois = [{{id:'1', group:'g', module:'old', points:[{{x:1,y:2}}]}}];
+        let pageRois = [];
+        let otherRois = [];
         let currentSource = 'src';
         let fetchOpts;
         global.fetch = (url, opts) => {{ fetchOpts = opts; return Promise.resolve({{}}); }};


### PR DESCRIPTION
## Summary
- support selecting page-type ROIs in ROI selection page
- display page ROIs in table with crop action and save image as base64
- update ROI storage to include page name and image
- add tests for page ROI rectangle creation

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689dfa5ebb54832b87e3ec54213a3e2a