### PR TITLE
เพิ่มปุ่ม Crop/Delete ใน Page ROI List

### DIFF
--- a/templates/roi_selection.html
+++ b/templates/roi_selection.html
@@ -553,13 +553,18 @@
                     tr.appendChild(imgTd);
 
                     const actionTd = document.createElement('td');
-                    if (!r.image) {
-                        const btn = document.createElement('button');
-                        btn.textContent = 'Crop';
-                        btn.className = 'btn btn-primary btn-sm';
-                        btn.addEventListener('click', () => cropPageRoi(idx));
-                        actionTd.appendChild(btn);
-                    }
+                    const cropBtn = document.createElement('button');
+                    cropBtn.textContent = 'Crop';
+                    cropBtn.className = 'btn btn-primary btn-sm me-2';
+                    cropBtn.addEventListener('click', () => cropPageRoi(idx));
+                    actionTd.appendChild(cropBtn);
+
+                    const delBtn = document.createElement('button');
+                    delBtn.textContent = 'Delete';
+                    delBtn.className = 'btn btn-danger btn-sm';
+                    delBtn.addEventListener('click', () => deletePageRoi(idx));
+                    actionTd.appendChild(delBtn);
+
                     tr.appendChild(actionTd);
 
                     tbody.appendChild(tr);
@@ -687,6 +692,22 @@
 
         }
 
+        function deletePageRoi(i) {
+            pageRois.splice(i, 1);
+            drawAllRois();
+            renderRoiList();
+
+            fetch('/save_roi', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ rois: rois.concat(pageRois).concat(typeof otherRois !== 'undefined' ? otherRois : []), source: currentSource })
+            })
+            .then(res => res.json())
+            .then(data => {
+                if (typeof showAlert === 'function') showAlert('Deleted. Saved to: ' + data.filename, 'success');
+            });
+        }
+
         async function cropPageRoi(i) {
             const nameInput = document.getElementById(`page_${i}`);
             const pageName = nameInput.value.trim();
@@ -738,6 +759,7 @@
         window.updateRoiGroup = updateRoiGroup;
         window.updateRoiModule = updateRoiModule;
         window.deleteRoi = deleteRoi;
+        window.deletePageRoi = deletePageRoi;
 
         window.addEventListener('beforeunload', () => {
             stopStream();

--- a/tests/test_roi_selection_delete_page_roi.py
+++ b/tests/test_roi_selection_delete_page_roi.py
@@ -1,0 +1,34 @@
+import json
+import re
+import subprocess
+import textwrap
+from pathlib import Path
+
+
+def test_delete_page_roi_removes_and_saves():
+    html = Path('templates/roi_selection.html').read_text()
+    match = re.search(r"function deletePageRoi\s*\(i\)\s*{[\s\S]*?}\n", html)
+    assert match, 'deletePageRoi function not found'
+    func_text = match.group(0)
+
+    script = textwrap.dedent("""
+        let rois = [];
+        let pageRois = [{id:'1', points:[{x:1, y:2}]}];
+        let otherRois = [];
+        let currentSource = 'src';
+        function drawAllRois(){};
+        function renderRoiList(){};
+        let fetchOpts;
+        global.fetch = (url, opts) => { fetchOpts = opts; return Promise.resolve({json: () => Promise.resolve({filename:'f'})}); };
+        __FUNC_TEXT__
+        deletePageRoi(0);
+        console.log(JSON.stringify({pageRois, fetchOpts}));
+        """).replace('__FUNC_TEXT__', func_text)
+
+    result = subprocess.run(['node', '-e', script], capture_output=True, text=True, check=True)
+    data = json.loads(result.stdout.strip())
+    assert data['pageRois'] == []
+    body = json.loads(data['fetchOpts']['body'])
+    assert body['rois'] == []
+    assert body['source'] == 'src'
+


### PR DESCRIPTION
## สรุป
- เพิ่มปุ่ม Crop และ Delete ให้ Page ROI List เพื่อจัดการรูปและข้อมูลได้สะดวก
- เพิ่มฟังก์ชัน deletePageRoi สำหรับลบ ROI ของหน้าที่เลือกและบันทึกข้อมูล
- เพิ่มการทดสอบการลบ Page ROI

## การทดสอบ
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689e699ec87c832b9c810549cd3c491b