### PR TITLE
เพิ่มตัวเลือก Pages ในหน้า Inference

### DIFF
--- a/templates/partials/inference_content.html
+++ b/templates/partials/inference_content.html
@@ -118,13 +118,10 @@
             optAll.value = 'all';
             optAll.textContent = 'All';
             groupSelect.appendChild(optAll);
-            const hasPages = list.some(r => (r.type ?? 'roi') === 'page');
-            if (hasPages) {
-                const optPages = document.createElement('option');
-                optPages.value = 'pages';
-                optPages.textContent = 'Pages';
-                groupSelect.appendChild(optPages);
-            }
+            const optPages = document.createElement('option');
+            optPages.value = 'pages';
+            optPages.textContent = 'Pages';
+            groupSelect.appendChild(optPages);
             const groups = Array.from(
                 new Set(list.map(r => r.group).filter(g => g))
             );


### PR DESCRIPTION
## Summary
- แสดงตัวเลือก **Pages** ในกล่อง Group เสมอ เพื่อให้เลือก ROI ประเภท page ได้ง่าย

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689e8c5eb754832bacf02ae5ba61aa20