### PR TITLE
refactor: filter page rois

### DIFF
--- a/templates/partials/inference_content.html
+++ b/templates/partials/inference_content.html
@@ -170,7 +170,7 @@
                 : selectedGroup === 'all'
                     ? allRois
                     : selectedGroup === 'pages'
-                        ? allRois.filter(r => (r.type ?? 'roi') === 'page' || ((r.type ?? 'roi') === 'roi' && r.group === 'page1'))
+                        ? allRois.filter(r => (r.type ?? 'roi') === 'page')
                         : []);
             if (rois.length > 0) {
                 renderRoiPlaceholders();
@@ -274,7 +274,7 @@
                 rois = stored === 'all'
                     ? allRois
                     : stored === 'pages'
-                        ? allRois.filter(r => (r.type ?? 'roi') === 'page' || ((r.type ?? 'roi') === 'roi' && r.group === 'page1'))
+                        ? allRois.filter(r => (r.type ?? 'roi') === 'page')
                         : stored
                             ? allRois.filter(r => r.group === stored)
                             : [];
@@ -305,7 +305,7 @@
             const filtered = selected === 'all'
                 ? allRois
                 : selected === 'pages'
-                    ? allRois.filter(r => (r.type ?? 'roi') === 'page' || ((r.type ?? 'roi') === 'roi' && r.group === 'page1'))
+                    ? allRois.filter(r => (r.type ?? 'roi') === 'page')
                     : allRois.filter(r => r.group === selected);
             await stopInference();
             await startInference(filtered, selected);


### PR DESCRIPTION
## Summary
- show only page-type ROIs when selecting Pages

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689e914352e0832bb028c2cd85f10cf6