### PR TITLE
Ensure page ROI frame redraws during streaming

### DIFF
--- a/templates/partials/inference_content.html
+++ b/templates/partials/inference_content.html
@@ -212,6 +212,8 @@
             socket.onmessage = function(event) {
                 const blob = new Blob([event.data], { type: 'image/jpeg' });
                 video.src = URL.createObjectURL(blob);
+                // redraw overlay so page ROI frames stay visible
+                drawOverlay();
             };
         }
 

--- a/templates/roi_selection.html
+++ b/templates/roi_selection.html
@@ -151,6 +151,8 @@
             socket.onmessage = function(event) {
                 const blob = new Blob([event.data], { type: "image/jpeg" });
                 video.src = URL.createObjectURL(blob);
+                // redraw ROIs so page frames stay visible even when the video updates
+                drawAllRois();
             };
             socket.onclose = function() {
                 socket = null;


### PR DESCRIPTION
## Summary
- Redraw ROI overlays on each incoming video frame so page ROIs remain visible
- Apply the same redraw logic to inference view for consistent page ROI display

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689ee34b8fe0832b96e283c40e8b3543