### PR TITLE
Filter ROIs by type and module for inference

### DIFF
--- a/app.py
+++ b/app.py
@@ -215,6 +215,8 @@ async def run_inference_loop(cam_id: int):
             pts = r.get("points", [])
             if len(pts) != 4:
                 continue
+            if r.get("type") != "roi":
+                continue
             mod_name = r.get("module")
             if not mod_name:
                 print(f"module missing for ROI {r.get('id', i)}")
@@ -541,8 +543,7 @@ async def perform_start_inference(cam_id: int, rois=None, save_state: bool = Tru
         rois = []
     processed_rois = []
     for r in rois:
-        mod_name = r.get("module")
-        if mod_name:
+        if r.get("type") == "roi" and r.get("module"):
             processed_rois.append(r)
     inference_rois[cam_id] = processed_rois
     queue = get_roi_result_queue(cam_id)

--- a/tests/test_inference_page_switch.py
+++ b/tests/test_inference_page_switch.py
@@ -57,11 +57,13 @@ def test_inference_switches_module_by_page(monkeypatch):
     rois_page1 = [{
         "id": "1",
         "module": "A",
+        "type": "roi",
         "points": [{"x":0,"y":0},{"x":1,"y":0},{"x":1,"y":1},{"x":0,"y":1}],
     }]
     rois_page2 = [{
         "id": "1",
         "module": "B",
+        "type": "roi",
         "points": [{"x":0,"y":0},{"x":1,"y":0},{"x":1,"y":1},{"x":0,"y":1}],
     }]
 


### PR DESCRIPTION
## Summary
- run inference only for ROI entries with type `roi` and defined module
- filter ROIs before starting inference accordingly
- update inference page switch test to include ROI type

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689fcae21e34832bbfb8354906292f5a