### PR TITLE
feat: show real-time page score

### DIFF
--- a/templates/partials/inference_page_content.html
+++ b/templates/partials/inference_page_content.html
@@ -7,7 +7,7 @@
             <button id="cam1-startButton" class="btn btn-primary me-2">Start</button>
             <button id="cam1-stopButton" class="btn btn-danger" disabled>Stop</button>
             <p id="cam1-status"></p>
-            <p id="cam1-pageLabel" class="page-label"></p>
+            <p class="page-score">Page: <span id="cam1-pageLabel" class="page-label"></span> | Score: <span id="cam1-score" class="score-label"></span></p>
             <div class="compare-row">
                 <div class="video-wrapper">
                     <img id="cam1-video" width="320" height="240" />
@@ -15,7 +15,6 @@
                 </div>
                 <img id="cam1-refImage" class="ref-image" width="320" height="240" />
             </div>
-            <p id="cam1-score" class="score-label"></p>
         </div>
     </div>
     <div class="card roi-card">
@@ -180,6 +179,9 @@ function createPageController(cellId){
             openSocket();
             showAlert('Stream started','success');
             setRunningUI();
+            pageLabel.textContent='N/A';
+            scoreLabel.textContent='0%';
+            refImage.src='';
             await loadRoiFile(roiPath);
         }else{
             running=false;startButton.disabled=false;
@@ -241,7 +243,8 @@ function createPageController(cellId){
             overlay.height=bitmap.height;
             overlay.style.width=video.width+'px';
             overlay.style.height=video.height+'px';
-            let best=null;let bestScore=Infinity;
+            // ค้นหา ROI หน้า (page) ที่มีความเหมือนกับภาพปัจจุบันมากที่สุด
+            let best=null;let bestScore=-Infinity;
             for(const r of pageRois){
                 if(!r.bounds||!r.imageData) continue;
                 const {x,y,w,h}=r.bounds;
@@ -252,14 +255,17 @@ function createPageController(cellId){
                 for(let i=0;i<da.length;i+=4){
                     diff+=Math.abs(da[i]-db[i])+Math.abs(da[i+1]-db[i+1])+Math.abs(da[i+2]-db[i+2]);
                 }
-                diff/=w*h;
-                if(diff<bestScore){bestScore=diff;best=r;}
+                // ทำให้เป็นค่าความเหมือน 0..1 (1 = เหมือนมากที่สุด)
+                const sim = 1 - diff/(w*h*3*255);
+                if(sim>bestScore){bestScore=sim;best=r;}
             }
             drawPageOverlay(best);
-            const bestPage = best ? (best.page_name||best.page||best.name||'') : '';
-            pageLabel.textContent=bestPage;
+            const bestPage = best ? (best.page_name||best.page||best.name||'') : 'N/A';
+            pageLabel.textContent = bestPage;
             refImage.src = best ? best.imageSrc : '';
-            scoreLabel.textContent = best ? bestScore.toFixed(2) : '';
+            // แปลงคะแนนเป็นเปอร์เซ็นต์และแสดงผลเสมอ
+            const percent = best ? (bestScore*100).toFixed(2) : '0';
+            scoreLabel.textContent = `${percent}%`;
 
             if(best && bestPage!==currentPage){
                 await switchPage(bestPage);


### PR DESCRIPTION
## Summary
- show page and similarity score in one line
- initialize labels on stream start and update percent every frame

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689fee56c61c832b8eae692d945516cc