### PR TITLE
Use group output for ROI drawing

### DIFF
--- a/app.py
+++ b/app.py
@@ -205,7 +205,7 @@ async def run_inference_loop(cam_id: str):
             return cv2.resize(frame, (0, 0), fx=0.5, fy=0.5)
 
         save_flag = bool(save_roi_flags.get(cam_id))
-        best_name = None
+        output = None
         best_score = -1.0
         for i, r in enumerate(rois):
             if np is None:
@@ -301,22 +301,50 @@ async def run_inference_loop(cam_id: str):
                             score = float(res[0][0])
                             if score > best_score:
                                 best_score = score
-                                best_name = r.get('page', '')
+                                output = r.get('page', '')
                         except Exception:
                             pass
 
-            cv2.polylines(frame, [src.astype(int)], True, color, 2)
-            label_pt = src[0].astype(int)
-            cv2.putText(frame, str(r.get('id', i + 1)), (int(label_pt[0]), max(0, int(label_pt[1]) - 5)), cv2.FONT_HERSHEY_SIMPLEX, 0.5, color, 1, cv2.LINE_AA)
-        if best_name:
+            if typ == 'page':
+                cv2.polylines(frame, [src.astype(int)], True, color, 2)
+                label_pt = src[0].astype(int)
+                cv2.putText(
+                    frame,
+                    str(r.get('id', i + 1)),
+                    (int(label_pt[0]), max(0, int(label_pt[1]) - 5)),
+                    cv2.FONT_HERSHEY_SIMPLEX,
+                    0.5,
+                    color,
+                    1,
+                    cv2.LINE_AA,
+                )
+        if output:
             try:
                 q = get_roi_result_queue(cam_id)
-                payload = json.dumps({'page': best_name})
+                payload = json.dumps({'group': output})
                 if q.full():
                     q.get_nowait()
                 await q.put(payload)
             except Exception:
                 pass
+            for i, r in enumerate(rois):
+                if r.get('type') == 'roi' and r.get('group') == output:
+                    pts = r.get('points', [])
+                    if len(pts) != 4:
+                        continue
+                    src = np.array([[p['x'], p['y']] for p in pts], dtype=np.int32)
+                    cv2.polylines(frame, [src], True, (255, 0, 0), 2)
+                    label_pt = src[0]
+                    cv2.putText(
+                        frame,
+                        str(r.get('id', i + 1)),
+                        (int(label_pt[0]), max(0, int(label_pt[1]) - 5)),
+                        cv2.FONT_HERSHEY_SIMPLEX,
+                        0.5,
+                        (255, 0, 0),
+                        1,
+                        cv2.LINE_AA,
+                    )
         return cv2.resize(frame, (0, 0), fx=0.5, fy=0.5)
 
     queue = get_frame_queue(cam_id)

--- a/templates/partials/inference_page_content.html
+++ b/templates/partials/inference_page_content.html
@@ -139,8 +139,8 @@ function createController(cellId){
         roiSocket.onmessage=event=>{
             try{
                 const data=JSON.parse(event.data);
-                if(data.page){
-                    pageNameEl.innerText=data.page;
+                if(data.group){
+                    pageNameEl.innerText=data.group;
                 }
             }catch(e){}
         };


### PR DESCRIPTION
## Summary
- track page inference as `group` output
- highlight `roi` items whose `group` matches output
- listen for `group` messages on the page inference display

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a00622547c832bbec223a8319a9eda