### PR TITLE
Crop ROI by detected page

### DIFF
--- a/app.py
+++ b/app.py
@@ -205,19 +205,79 @@ async def run_inference_loop(cam_id: str):
             return cv2.resize(frame, (0, 0), fx=0.5, fy=0.5)
 
         save_flag = bool(save_roi_flags.get(cam_id))
-        best_name = None
+        output = None
         best_score = -1.0
+
+        # pass 1: evaluate page ROIs to determine best group and draw them
         for i, r in enumerate(rois):
+            if np is None or r.get('type') != 'page':
+                continue
+            pts = r.get('points', [])
+            if len(pts) != 4:
+                continue
+            src = np.array([[p['x'], p['y']] for p in pts], dtype=np.float32)
+            color = (0, 255, 0)
+            width_a = np.linalg.norm(src[0] - src[1])
+            width_b = np.linalg.norm(src[2] - src[3])
+            max_w = int(max(width_a, width_b))
+            height_a = np.linalg.norm(src[0] - src[3])
+            height_b = np.linalg.norm(src[1] - src[2])
+            max_h = int(max(height_a, height_b))
+            dst = np.array([[0, 0], [max_w - 1, 0], [max_w - 1, max_h - 1], [0, max_h - 1]], dtype=np.float32)
+            matrix = cv2.getPerspectiveTransform(src, dst)
+            roi = cv2.warpPerspective(frame, matrix, (max_w, max_h))
+            template = r.get('_template')
+            if template is not None:
+                try:
+                    roi_gray = cv2.cvtColor(roi, cv2.COLOR_BGR2GRAY)
+                except Exception:
+                    roi_gray = None
+                if roi_gray is not None:
+                    if roi_gray.shape != template.shape:
+                        roi_gray = cv2.resize(roi_gray, (template.shape[1], template.shape[0]))
+                    try:
+                        res = cv2.matchTemplate(roi_gray, template, cv2.TM_CCOEFF_NORMED)
+                        score = float(res[0][0])
+                        if score > best_score:
+                            best_score = score
+                            output = r.get('page', '')
+                    except Exception:
+                        pass
+            cv2.polylines(frame, [src.astype(int)], True, color, 2)
+            label_pt = src[0].astype(int)
+            cv2.putText(
+                frame,
+                str(r.get('id', i + 1)),
+                (int(label_pt[0]), max(0, int(label_pt[1]) - 5)),
+                cv2.FONT_HERSHEY_SIMPLEX,
+                0.5,
+                color,
+                1,
+                cv2.LINE_AA,
+            )
+
+        # pass 2: process ROI items that belong to detected group
+        if output:
+            try:
+                q = get_roi_result_queue(cam_id)
+                payload = json.dumps({'group': output})
+                if q.full():
+                    q.get_nowait()
+                await q.put(payload)
+            except Exception:
+                pass
+
+        for i, r in enumerate(rois):
+            if r.get('type') != 'roi' or r.get('group') != output:
+                continue
             if np is None:
                 continue
             pts = r.get('points', [])
             if len(pts) != 4:
                 continue
             src = np.array([[p['x'], p['y']] for p in pts], dtype=np.float32)
-            typ = r.get('type')
-            color = (255, 0, 0) if typ == 'roi' else (0, 255, 0)
 
-            if typ == 'roi' and r.get('module'):
+            if r.get('module'):
                 mod_name = r.get('module')
                 module_entry = module_cache.get(mod_name)
                 if module_entry is None:
@@ -275,48 +335,23 @@ async def run_inference_loop(cam_id: str):
                             await q.put(payload)
                         except Exception:
                             pass
-            elif typ == 'roi' and not r.get('module'):
+            else:
                 print(f"module missing for ROI {r.get('id', i)}")
-            elif typ == 'page':
-                width_a = np.linalg.norm(src[0] - src[1])
-                width_b = np.linalg.norm(src[2] - src[3])
-                max_w = int(max(width_a, width_b))
-                height_a = np.linalg.norm(src[0] - src[3])
-                height_b = np.linalg.norm(src[1] - src[2])
-                max_h = int(max(height_a, height_b))
-                dst = np.array([[0, 0], [max_w - 1, 0], [max_w - 1, max_h - 1], [0, max_h - 1]], dtype=np.float32)
-                matrix = cv2.getPerspectiveTransform(src, dst)
-                roi = cv2.warpPerspective(frame, matrix, (max_w, max_h))
-                template = r.get('_template')
-                if template is not None:
-                    try:
-                        roi_gray = cv2.cvtColor(roi, cv2.COLOR_BGR2GRAY)
-                    except Exception:
-                        roi_gray = None
-                    if roi_gray is not None:
-                        if roi_gray.shape != template.shape:
-                            roi_gray = cv2.resize(roi_gray, (template.shape[1], template.shape[0]))
-                        try:
-                            res = cv2.matchTemplate(roi_gray, template, cv2.TM_CCOEFF_NORMED)
-                            score = float(res[0][0])
-                            if score > best_score:
-                                best_score = score
-                                best_name = r.get('page', '')
-                        except Exception:
-                            pass
 
-            cv2.polylines(frame, [src.astype(int)], True, color, 2)
-            label_pt = src[0].astype(int)
-            cv2.putText(frame, str(r.get('id', i + 1)), (int(label_pt[0]), max(0, int(label_pt[1]) - 5)), cv2.FONT_HERSHEY_SIMPLEX, 0.5, color, 1, cv2.LINE_AA)
-        if best_name:
-            try:
-                q = get_roi_result_queue(cam_id)
-                payload = json.dumps({'page': best_name})
-                if q.full():
-                    q.get_nowait()
-                await q.put(payload)
-            except Exception:
-                pass
+            src_int = src.astype(int)
+            cv2.polylines(frame, [src_int], True, (255, 0, 0), 2)
+            label_pt = src_int[0]
+            cv2.putText(
+                frame,
+                str(r.get('id', i + 1)),
+                (int(label_pt[0]), max(0, int(label_pt[1]) - 5)),
+                cv2.FONT_HERSHEY_SIMPLEX,
+                0.5,
+                (255, 0, 0),
+                1,
+                cv2.LINE_AA,
+            )
+
         return cv2.resize(frame, (0, 0), fx=0.5, fy=0.5)
 
     queue = get_frame_queue(cam_id)

--- a/templates/partials/inference_page_content.html
+++ b/templates/partials/inference_page_content.html
@@ -13,6 +13,9 @@
             </div>
         </div>
     </div>
+    <div class="card roi-card">
+        <div id="cam1-rois" class="roi-grid"></div>
+    </div>
 </div>
 <script>
 (function(){
@@ -24,6 +27,8 @@ function createController(cellId){
     const getEl=suffix=>document.getElementById(`${cellId}-${suffix}`);
     const video=getEl('video');
     const pageNameEl=getEl('pageName');
+    const roiGrid=getEl('rois');
+    let rois=[];
 
     const startButton=getEl('startButton');
     const stopButton=getEl('stopButton');
@@ -106,6 +111,13 @@ function createController(cellId){
             showAlert('Failed to load ROI file','error');
         }
 
+        rois=roiList.filter(r=>r.type==='roi');
+        if(rois.length>0){
+            renderRoiPlaceholders();
+        }else{
+            roiGrid.innerHTML='';
+        }
+
         const startRes=await fetchWithStatus(`/start_inference/${cam}`,{
             method:'POST',headers:{'Content-Type':'application/json'},
             body:JSON.stringify({...cfg,rois:roiList})
@@ -139,11 +151,37 @@ function createController(cellId){
         roiSocket.onmessage=event=>{
             try{
                 const data=JSON.parse(event.data);
-                if(data.page){
-                    pageNameEl.innerText=data.page;
+                if(data.group){
+                    pageNameEl.innerText=data.group;
+                }else if(data.id){
+                    const imgEl=document.getElementById(`${cellId}-roi-${data.id}`);
+                    if(imgEl){imgEl.src=`data:image/jpeg;base64,${data.image}`;}
+                    const textEl=document.getElementById(`${cellId}-text-${data.id}`);
+                    if(textEl){textEl.textContent=data.text||'';}
                 }
             }catch(e){}
         };
+    }
+
+    function renderRoiPlaceholders(list=rois){
+        roiGrid.innerHTML='';
+        list.forEach(r=>{
+            const item=document.createElement('div');
+            item.className='roi-item';
+            const title=document.createElement('h4');
+            title.className='roi-title';
+            title.textContent=r.name||`ROI ${r.id}`;
+            const img=document.createElement('img');
+            img.id=`${cellId}-roi-${r.id}`;
+            img.className='roi-image';
+            const p=document.createElement('p');
+            p.id=`${cellId}-text-${r.id}`;
+            p.className='roi-text';
+            item.appendChild(title);
+            item.appendChild(img);
+            item.appendChild(p);
+            roiGrid.appendChild(item);
+        });
     }
 
     async function stopStream(){
@@ -178,8 +216,19 @@ function createController(cellId){
                 }
             }catch(e){}
             if(data.running){
+                const name=sourceSelect.value;
                 openSocket();
                 openRoiSocket();
+                if(name){
+                    const cfgRes=await fetchWithStatus(`/source_config?name=${encodeURIComponent(name)}`);
+                    const cfg=await cfgRes.json();
+                    let roiPath=cfg.rois;
+                    if(!roiPath.startsWith('/'))roiPath=`data_sources/${cfg.name}/${roiPath}`;
+                    const roiRes=await fetchWithStatus(`/load_roi_file?path=${encodeURIComponent(roiPath)}`);
+                    const roiData=await roiRes.json();
+                    rois=(roiData.rois||[]).filter(r=>r.type==='roi');
+                    if(rois.length>0)renderRoiPlaceholders();
+                }
                 setRunningUI();
                 running=true;
                 showAlert('Stream resumed','info');


### PR DESCRIPTION
## Summary
- แยกขั้นตอนหา page ก่อน แล้วจึงประมวลผล ROI เฉพาะที่อยู่ในกลุ่มที่ตรวจพบ
- ตัดภาพ ROI ที่ตรงกับ group ส่งเข้าโมดูล inference และวาดกรอบสีน้ำเงิน
- หน้า inference page แสดงผล ROI เป็นกริดด้านขวาและอัปเดตผ่าน WebSocket

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a00622547c832bbec223a8319a9eda