### PR TITLE
fix: support group names from page ROI fields

### DIFF
--- a/templates/partials/inference_content.html
+++ b/templates/partials/inference_content.html
@@ -119,7 +119,12 @@
             optAll.textContent = 'All';
             groupSelect.appendChild(optAll);
             const groups = Array.from(
-                new Set(list.map(r => r.group).filter(p => p))
+                new Set(
+                    list
+                        .filter(r => (r.type ?? 'roi') === 'roi')
+                        .map(r => r.group ?? r.page ?? r.name)
+                        .filter(p => p)
+                )
             );
             groups.forEach(p => {
                 const opt = document.createElement('option');
@@ -155,15 +160,18 @@
             const data = await res.json();
             statusEl.innerText = 'Loaded: ' + data.filename;
             allRois = data.rois || [];
+            const roiList = allRois.filter(r => (r.type ?? 'roi') === 'roi');
             if (selectedGroup) {
                 localStorage.setItem(`${cellId}-group`, selectedGroup);
             } else {
                 localStorage.removeItem(`${cellId}-group`);
             }
-            loadGroupOptions(allRois, selectedGroup);
+            loadGroupOptions(roiList, selectedGroup);
             rois = roisOverride || (selectedGroup && selectedGroup !== 'all'
-                ? allRois.filter(r => r.group === selectedGroup)
-                : selectedGroup === 'all' ? allRois : []);
+                ? roiList.filter(r => (r.group ?? r.page ?? r.name) === selectedGroup)
+                : selectedGroup === 'all'
+                    ? roiList
+                    : []);
             if (rois.length > 0) {
                 renderRoiPlaceholders();
             } else {
@@ -257,9 +265,14 @@
                 const roiRes = await fetchWithStatus(`/load_roi_file?path=${encodeURIComponent(roiPath)}`);
                 const roiData = await roiRes.json();
                 allRois = roiData.rois || [];
-                loadGroupOptions(allRois);
+                const roiList = allRois.filter(r => (r.type ?? 'roi') === 'roi');
+                loadGroupOptions(roiList);
                 const stored = groupSelect.value;
-                rois = stored === 'all' ? allRois : stored ? allRois.filter(r => r.group === stored) : [];
+                rois = stored === 'all'
+                    ? roiList
+                    : stored
+                        ? roiList.filter(r => (r.group ?? r.page ?? r.name) === stored)
+                        : [];
                 await fetchWithStatus(`/start_inference/${cam}`, {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
@@ -284,7 +297,10 @@
             const selected = groupSelect.value;
             if (!selected) return;
             localStorage.setItem(`${cellId}-group`, selected);
-            const filtered = selected === 'all' ? allRois : allRois.filter(r => r.group === selected);
+            const roiList = allRois.filter(r => (r.type ?? 'roi') === 'roi');
+            const filtered = selected === 'all'
+                ? roiList
+                : roiList.filter(r => (r.group ?? r.page ?? r.name) === selected);
             await stopInference();
             await startInference(filtered, selected);
         }


### PR DESCRIPTION
## Summary
- allow inference group dropdown to read `group`, `page`, or `name` fields
- ensure ROI filtering uses these fields consistently
- restrict group options to entries where `type` is `roi`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a016e601dc832bacc98e76a9620845