### PR TITLE
Ensure ROI filtering respects group selection in inference page

### DIFF
--- a/app.py
+++ b/app.py
@@ -268,7 +268,9 @@ async def run_inference_loop(cam_id: str):
                 pass
 
         for i, r in enumerate(rois):
-            if r.get('type') != 'roi' or r.get('group') != output:
+            if r.get('type') != 'roi':
+                continue
+            if output and r.get('group') != output:
                 continue
             if np is None:
                 continue


### PR DESCRIPTION
## Summary
- Process ROIs even when no page group is detected, allowing inference grid to show selected group results

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a01f747398832b92ba9b568379d4ec