### PR TITLE
Clarify inference pages and add tests

### DIFF
--- a/app.py
+++ b/app.py
@@ -120,13 +120,16 @@ async def roi_page():
 
 # ✅ หน้า inference
 @app.route("/inference")
-async def inference():
+async def inference() -> str:
+    """แสดงหน้า Inference สำหรับรันโมดูลตาม ROI ที่บันทึกไว้"""
     return await render_template("inference.html")
 
 # ✅ หน้า inference page detection
 @app.route("/inference_page")
-async def inference_page():
+async def inference_page() -> str:
+    """แสดงหน้า Inference Page สำหรับตรวจจับหน้ากระดาษ"""
     return await render_template("inference_page.html")
+
 
 
 def load_custom_module(name: str) -> ModuleType | None:

--- a/tests/test_inference_routes.py
+++ b/tests/test_inference_routes.py
@@ -1,0 +1,10 @@
+import pytest
+from app import app
+
+@pytest.mark.asyncio
+async def test_inference_routes():
+    client = app.test_client()
+    resp = await client.get('/inference')
+    assert resp.status_code == 200
+    resp = await client.get('/inference_page')
+    assert resp.status_code == 200


### PR DESCRIPTION
## Summary
- Describe inference and inference_page endpoints with docstrings
- Add tests ensuring both inference routes render successfully

## Testing
- `pytest -q` *(fails: pytest: No such file or directory)*
- `python -m pytest -q` *(fails: python: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a0236a6e9c832bb98ac2ab0db463f7