### PR TITLE
Add output label to inference page

### DIFF
--- a/templates/partials/inference_page_content.html
+++ b/templates/partials/inference_page_content.html
@@ -9,7 +9,7 @@
             <p id="cam1-status"></p>
             <div class="video-wrapper">
                 <img id="cam1-video" width="320" height="240" />
-                <p id="cam1-pageName"></p>
+                <p>output: <span id="cam1-pageName"></span></p>
             </div>
         </div>
     </div>


### PR DESCRIPTION
## Summary
- prepend "output" label to page name section on inference page

## Testing
- `pytest -q` (fails: async def functions are not natively supported; missing pytest-asyncio)


------
https://chatgpt.com/codex/tasks/task_e_68a04861a8dc832baa7427749141c0dd