### PR TITLE
Allow renaming and saving page ROI names

### DIFF
--- a/templates/roi_selection.html
+++ b/templates/roi_selection.html
@@ -539,7 +539,7 @@
                     input.className = 'form-control form-control-sm';
                     input.id = `page_${idx}`;
                     input.value = r.page || '';
-                    if (r.image) input.disabled = true;
+                    input.addEventListener('change', e => updatePageRoiName(idx, e.target.value));
                     tdPage.appendChild(input);
                     tr.appendChild(tdPage);
 
@@ -677,6 +677,16 @@
             });
         }
 
+        function updatePageRoiName(i, name) {
+            pageRois[i].page = name;
+            pageRois[i].name = name;
+            fetch('/save_roi', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ rois: rois.concat(pageRois).concat(typeof otherRois !== 'undefined' ? otherRois : []), source: currentSource })
+            });
+        }
+
         function deleteRoi(i) {
             if (!confirm('Delete this ROI?')) return;
             rois.splice(i, 1);
@@ -763,6 +773,7 @@
         window.updateRoiGroup = updateRoiGroup;
         window.updateRoiModule = updateRoiModule;
         window.deleteRoi = deleteRoi;
+        window.updatePageRoiName = updatePageRoiName;
         window.deletePageRoi = deletePageRoi;
 
         window.addEventListener('beforeunload', () => {

--- a/tests/test_roi_selection_update_page_name.py
+++ b/tests/test_roi_selection_update_page_name.py
@@ -1,0 +1,32 @@
+import json
+import re
+import subprocess
+import textwrap
+from pathlib import Path
+
+
+def test_update_page_roi_name_triggers_save():
+    html = Path('templates/roi_selection.html').read_text()
+    match = re.search(r"function updatePageRoiName\s*\(i, name\)\s*{[\s\S]*?}\n", html)
+    assert match, 'updatePageRoiName function not found'
+    func_text = match.group(0)
+
+    script = textwrap.dedent(
+        f"""
+        let rois = [];
+        let pageRois = [{{id:'p1', page:'old', name:'old', points:[{{x:1,y:2}}]}}];
+        let otherRois = [];
+        let currentSource = 'src';
+        let fetchOpts;
+        global.fetch = (url, opts) => {{ fetchOpts = opts; return Promise.resolve({{}}); }};
+        {func_text}
+        updatePageRoiName(0, 'new');
+        console.log(fetchOpts.body);
+        """
+    )
+
+    result = subprocess.run(['node', '-e', script], capture_output=True, text=True, check=True)
+    body = json.loads(result.stdout.strip())
+    assert body['rois'][0]['page'] == 'new'
+    assert body['rois'][0]['name'] == 'new'
+    assert body['source'] == 'src'


### PR DESCRIPTION
## Summary
- Allow editing Page ROI names and persist changes
- Add tests verifying page name updates trigger saving

## Testing
- `pytest`
- `pytest tests/test_roi_selection_update_page_name.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a04d51fddc832b9c733b64940b0785