### PR TITLE
Add confirmation for Page ROI deletion

### DIFF
--- a/templates/roi_selection.html
+++ b/templates/roi_selection.html
@@ -706,6 +706,7 @@
         }
 
         function deletePageRoi(i) {
+            if (!confirm('Delete this Page ROI?')) return;
             pageRois.splice(i, 1);
             drawAllRois();
             renderRoiList();

--- a/tests/test_roi_selection_delete_page_roi.py
+++ b/tests/test_roi_selection_delete_page_roi.py
@@ -19,10 +19,12 @@ def test_delete_page_roi_removes_and_saves():
         function drawAllRois(){};
         function renderRoiList(){};
         let fetchOpts;
+        let confirmCalls = [];
+        global.confirm = msg => { confirmCalls.push(msg); return true; };
         global.fetch = (url, opts) => { fetchOpts = opts; return Promise.resolve({json: () => Promise.resolve({filename:'f'})}); };
         __FUNC_TEXT__
         deletePageRoi(0);
-        console.log(JSON.stringify({pageRois, fetchOpts}));
+        console.log(JSON.stringify({pageRois, fetchOpts, confirmCalls}));
         """).replace('__FUNC_TEXT__', func_text)
 
     result = subprocess.run(['node', '-e', script], capture_output=True, text=True, check=True)
@@ -31,4 +33,5 @@ def test_delete_page_roi_removes_and_saves():
     body = json.loads(data['fetchOpts']['body'])
     assert body['rois'] == []
     assert body['source'] == 'src'
+    assert data['confirmCalls'] == ['Delete this Page ROI?']
 


### PR DESCRIPTION
## Summary
- prompt user before deleting items from the Page ROI list
- cover the confirmation behavior with updated unit test

## Testing
- `pytest -q` *(fails: async def functions are not natively supported)*
- `pytest tests/test_roi_selection_delete_page_roi.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a0506271c0832ba337cdb67665a97f