### PR TITLE
ปรับ UI ให้รองรับ Bootstrap และ Responsive

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -43,7 +43,7 @@ main {
 
 .camera-grid {
   display: grid;
-  grid-template-columns: repeat(2, 1fr);
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
   gap: 20px;
 }
 
@@ -54,13 +54,6 @@ main {
   padding: 10px;
 }
 
-.roi-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, 80px);
-  gap: 8px;
-  margin-left: 10px;
-  padding: 10px;
-}
 
 .roi-item {
   display: flex;
@@ -99,24 +92,9 @@ main {
   margin-bottom: 20px;
 }
 
-.cam-row {
-  display: flex;
-  align-items: flex-start;
-  gap: 10px;
-  margin-bottom: 20px;
-}
-
 .video-wrapper {
   position: relative;
   display: inline-block;
-}
-
-.roi-card {
-  display: flex;
-  align-items: flex-start;
-  /* Ensure ROI card is visible even before ROIs load and prevent wrapping under the video */
-  min-width: 200px;
-  flex-shrink: 0;
 }
 
 /* Table styling for source list and generic tables */

--- a/templates/create_source.html
+++ b/templates/create_source.html
@@ -4,33 +4,38 @@
 
 <h2>Create Source</h2>
 
+<div class="container">
 <form id="create-form" method="POST" action="/create_source">
-    <div>
-        <label for="name">Name:</label>
-        <input type="text" id="name" name="name" required>
+    <div class="mb-3">
+        <label for="name" class="form-label">Name:</label>
+        <input type="text" id="name" name="name" class="form-control" required>
     </div>
     <div class="mb-3">
         <label for="source" class="form-label">Source:</label>
         <input type="text" id="source" name="source" class="form-control" required>
     </div>
-    <div class="mb-3 d-flex gap-3">
-        <div class="d-flex align-items-center">
-            <label class="me-2 mb-0">
-                <input type="checkbox" id="width-toggle"> Width:
-            </label>
-            <input type="number" id="width" name="width" class="form-control" style="max-width:150px;" disabled>
+    <div class="row mb-3">
+        <div class="col-md-6">
+            <div class="form-check mb-2">
+                <input type="checkbox" id="width-toggle" class="form-check-input">
+                <label for="width-toggle" class="form-check-label">Width</label>
+            </div>
+            <input type="number" id="width" name="width" class="form-control" disabled>
         </div>
-        <div class="d-flex align-items-center">
-            <label class="me-2 mb-0">
-                <input type="checkbox" id="height-toggle"> Height:
-            </label>
-            <input type="number" id="height" name="height" class="form-control" style="max-width:150px;" disabled>
+        <div class="col-md-6">
+            <div class="form-check mb-2">
+                <input type="checkbox" id="height-toggle" class="form-check-input">
+                <label for="height-toggle" class="form-check-label">Height</label>
+            </div>
+            <input type="number" id="height" name="height" class="form-control" disabled>
         </div>
     </div>
     <button type="submit" class="btn btn-primary">Create</button>
 </form>
+</div>
 
 <h3>Source List</h3>
+<div class="table-responsive">
 <table class="table table-bordered mt-3">
     <thead>
         <tr>
@@ -44,6 +49,7 @@
     <tbody id="source-table-body">
     </tbody>
 </table>
+</div>
 
 <script>
     const widthToggle = document.getElementById('width-toggle');

--- a/templates/partials/alert.html
+++ b/templates/partials/alert.html
@@ -1,36 +1,16 @@
-<div id="alert-box" class="alert" style="display:none;"></div>
+<div id="alert-box" class="alert alert-info position-fixed top-0 end-0 m-3 d-none" role="alert"></div>
 <script>
 function showAlert(message, type='info', timeout=3000) {
   const box = document.getElementById('alert-box');
   if (!box) return;
   box.textContent = message;
-  box.className = 'alert ' + type;
-  box.style.display = 'block';
+  box.classList.remove('alert-info', 'alert-success', 'alert-danger', 'alert-warning');
+  const mapped = type === 'error' ? 'danger' : type;
+  box.classList.add(`alert-${mapped}`);
+  box.classList.remove('d-none');
   setTimeout(() => {
-    box.style.display = 'none';
+    box.classList.add('d-none');
   }, timeout);
 }
 window.showAlert = showAlert;
 </script>
-<style>
-.alert {
-  position: fixed;
-  top: calc(var(--header-height) + 10px);
-  right: 20px;
-  padding: 10px 20px;
-  border: 1px solid #003366;
-  background-color: #b2d4ff;
-  color: #003366;
-  z-index: 1100;
-}
-.alert.success {
-  background-color: #d4edda;
-  color: #155724;
-  border-color: #c3e6cb;
-}
-.alert.error {
-  background-color: #f8d7da;
-  color: #721c24;
-  border-color: #f5c6cb;
-}
-</style>

--- a/templates/partials/inference_content.html
+++ b/templates/partials/inference_content.html
@@ -1,20 +1,24 @@
 <h2>Inference with Saved ROI</h2>
 <p>Modules are defined in the ROI file.</p>
-<div class="cam-row">
-    <div class="card">
-        <div id="cam1" class="cam-cell">
-            <select id="cam1-sourceSelect" class="form-select mb-2"></select>
-            <button id="cam1-startButton" class="btn btn-primary me-2">Start</button>
-            <button id="cam1-stopButton" class="btn btn-danger" disabled>Stop</button>
-            <p id="cam1-status"></p>
-            <div class="video-wrapper">
-                <img id="cam1-video" width="320" height="240" />
+<div class="row g-3">
+    <div class="col-12 col-md-6">
+        <div class="card">
+            <div id="cam1" class="cam-cell">
+                <select id="cam1-sourceSelect" class="form-select mb-2"></select>
+                <button id="cam1-startButton" class="btn btn-primary me-2">Start</button>
+                <button id="cam1-stopButton" class="btn btn-danger" disabled>Stop</button>
+                <p id="cam1-status"></p>
+                <div class="video-wrapper">
+                    <img id="cam1-video" class="img-fluid" />
+                </div>
             </div>
         </div>
     </div>
-    <div class="card roi-card">
-        <select id="cam1-groupSelect" class="form-select mb-2"></select>
-        <div id="cam1-rois" class="roi-grid"></div>
+    <div class="col-12 col-md-6">
+        <div class="card">
+            <select id="cam1-groupSelect" class="form-select mb-2"></select>
+            <div id="cam1-rois" class="row row-cols-2 row-cols-sm-3 g-2"></div>
+        </div>
     </div>
 </div>
   <script>
@@ -90,6 +94,8 @@
         function renderRoiPlaceholders(list = rois) {
             roiGrid.innerHTML = '';
             list.forEach(r => {
+                const col = document.createElement('div');
+                col.className = 'col';
                 const item = document.createElement('div');
                 item.className = 'roi-item';
                 const title = document.createElement('h4');
@@ -104,7 +110,8 @@
                 item.appendChild(title);
                 item.appendChild(img);
                 item.appendChild(p);
-                roiGrid.appendChild(item);
+                col.appendChild(item);
+                roiGrid.appendChild(col);
             });
         }
 

--- a/templates/partials/inference_page_content.html
+++ b/templates/partials/inference_page_content.html
@@ -1,20 +1,24 @@
 <h2>Inference Page</h2>
 <p>Stream camera with ROI overlay.</p>
-<div class="cam-row">
-    <div class="card">
-        <div id="cam1" class="cam-cell">
-            <select id="cam1-sourceSelect" class="form-select mb-2"></select>
-            <button id="cam1-startButton" class="btn btn-primary me-2">Start</button>
-            <button id="cam1-stopButton" class="btn btn-danger" disabled>Stop</button>
-            <p id="cam1-status"></p>
-            <div class="video-wrapper">
-                <img id="cam1-video" width="320" height="240" />
-                <p>page: <span id="cam1-pageName"></span></p>
+<div class="row g-3">
+    <div class="col-12 col-md-6">
+        <div class="card">
+            <div id="cam1" class="cam-cell">
+                <select id="cam1-sourceSelect" class="form-select mb-2"></select>
+                <button id="cam1-startButton" class="btn btn-primary me-2">Start</button>
+                <button id="cam1-stopButton" class="btn btn-danger" disabled>Stop</button>
+                <p id="cam1-status"></p>
+                <div class="video-wrapper">
+                    <img id="cam1-video" class="img-fluid" />
+                    <p>page: <span id="cam1-pageName"></span></p>
+                </div>
             </div>
         </div>
     </div>
-    <div class="card roi-card">
-        <div id="cam1-rois" class="roi-grid"></div>
+    <div class="col-12 col-md-6">
+        <div class="card">
+            <div id="cam1-rois" class="row row-cols-2 row-cols-sm-3 g-2"></div>
+        </div>
     </div>
 </div>
 <script>
@@ -167,6 +171,8 @@ function createController(cellId){
     function renderRoiPlaceholders(list=rois){
         roiGrid.innerHTML='';
         list.forEach(r=>{
+            const col=document.createElement('div');
+            col.className='col';
             const item=document.createElement('div');
             item.className='roi-item';
             const title=document.createElement('h4');
@@ -181,7 +187,8 @@ function createController(cellId){
             item.appendChild(title);
             item.appendChild(img);
             item.appendChild(p);
-            roiGrid.appendChild(item);
+            col.appendChild(item);
+            roiGrid.appendChild(col);
         });
     }
 

--- a/templates/roi_selection.html
+++ b/templates/roi_selection.html
@@ -2,25 +2,43 @@
 {% block title %}ROI Selection{% endblock %}
 {% block content %}
 
-<select id="sourceSelect"></select>
-<button id="startBtn">Start</button>
-<button id="stopBtn" disabled>Stop</button>
-<button id="clearBtn">Clear All</button>
-
-<br><br>
-<div class="d-flex">
-    <div id="roiToolbar" class="btn-group-vertical me-2">
-        <button id="pickBtn" class="btn btn-primary">Pick Points</button>
-        <button id="rectBtn" class="btn btn-secondary">Rectangle</button>
-        <button id="pageBtn" class="btn btn-secondary">Page Rect</button>
-    </div>
-    <div id="frameContainer" style="position: relative; display: inline-block;">
-        <img id="video" />
-        <canvas id="canvas"></canvas>
+<div class="container my-3">
+    <div class="row g-2 align-items-center">
+        <div class="col-12 col-md-auto">
+            <select id="sourceSelect" class="form-select"></select>
+        </div>
+        <div class="col-12 col-md-auto">
+            <button id="startBtn" class="btn btn-primary w-100">Start</button>
+        </div>
+        <div class="col-12 col-md-auto">
+            <button id="stopBtn" class="btn btn-danger w-100" disabled>Stop</button>
+        </div>
+        <div class="col-12 col-md-auto">
+            <button id="clearBtn" class="btn btn-secondary w-100">Clear All</button>
+        </div>
     </div>
 </div>
 
-<div id="roiList"></div>
+<div class="container">
+    <div class="row">
+        <div class="col-12 col-lg-8">
+            <div class="d-flex mb-3">
+                <div id="roiToolbar" class="btn-group-vertical me-2">
+                    <button id="pickBtn" class="btn btn-primary">Pick Points</button>
+                    <button id="rectBtn" class="btn btn-secondary">Rectangle</button>
+                    <button id="pageBtn" class="btn btn-secondary">Page Rect</button>
+                </div>
+                <div id="frameContainer" class="position-relative d-inline-block">
+                    <img id="video" class="img-fluid" />
+                    <canvas id="canvas"></canvas>
+                </div>
+            </div>
+        </div>
+        <div class="col-12 col-lg-4">
+            <div id="roiList"></div>
+        </div>
+    </div>
+</div>
 
 <script>
     (function() {
@@ -97,8 +115,6 @@
                 canvas.height = video.naturalHeight;
                 canvas.style.width = video.naturalWidth + 'px';
                 canvas.style.height = video.naturalHeight + 'px';
-                frameContainer.style.width = video.naturalWidth + 'px';
-                frameContainer.style.height = video.naturalHeight + 'px';
                 initialized = true;
             }
             drawAllRois();


### PR DESCRIPTION
## Summary
- ปรับหน้าเลือก ROI ให้ใช้ Bootstrap และภาพย่อ–ขยายอัตโนมัติ
- ปรับเทมเพลต inference ต่าง ๆ เป็นกริด Bootstrap และปรับ ROI grid
- เปลี่ยนระบบแจ้งเตือนเป็น Bootstrap alert และปรับหน้า Create Source ให้เป็นมิตรกับมือถือ

## Testing
- `pytest` *(ล้มเหลว: ต้องใช้ปลั๊กอิน pytest-asyncio แต่ไม่สามารถติดตั้งได้ในสภาพแวดล้อม)*

------
https://chatgpt.com/codex/tasks/task_e_68a07e444ea4832b91d445ee41f3ab96