### PR TITLE
ล้างภาพเดิมเมื่อหยุดสตรีม

### DIFF
--- a/templates/partials/inference_content.html
+++ b/templates/partials/inference_content.html
@@ -231,6 +231,9 @@
                 const blob = new Blob([event.data], { type: 'image/jpeg' });
                 video.src = URL.createObjectURL(blob);
             };
+            socket.onclose = function() {
+                video.src = '';
+            };
         }
 
         function openRoiSocket() {
@@ -249,6 +252,14 @@
                 } catch (e) {
                     console.error('ROI message error', e);
                 }
+            };
+            roiSocket.onclose = function() {
+                roiGrid.querySelectorAll('img').forEach(img => {
+                    img.src = '';
+                });
+                roiGrid.querySelectorAll('p').forEach(p => {
+                    p.textContent = '';
+                });
             };
         }
 

--- a/templates/partials/inference_page_content.html
+++ b/templates/partials/inference_page_content.html
@@ -26,6 +26,7 @@ function createController(cellId){
     const cam=`page_${cellId}`;
     const getEl=suffix=>document.getElementById(`${cellId}-${suffix}`);
     const video=getEl('video');
+    video.onload=()=>URL.revokeObjectURL(video.src);
     const pageNameEl=getEl('pageName');
     const roiGrid=getEl('rois');
     let rois=[];
@@ -144,6 +145,9 @@ function createController(cellId){
             const blob=new Blob([event.data],{type:'image/jpeg'});
             video.src=URL.createObjectURL(blob);
         };
+        socket.onclose=()=>{
+            video.src='';
+        };
     }
 
     function openRoiSocket(){
@@ -161,6 +165,11 @@ function createController(cellId){
 
                 }
             }catch(e){}
+        };
+        roiSocket.onclose=()=>{
+            pageNameEl.innerText='';
+            roiGrid.querySelectorAll('img').forEach(img=>{img.src='';});
+            roiGrid.querySelectorAll('p').forEach(p=>{p.textContent='';});
         };
     }
 
@@ -193,6 +202,7 @@ function createController(cellId){
         if(roiSocket){roiSocket.close();roiSocket=null;}
         video.src='';
         pageNameEl.innerText='';
+        roiGrid.innerHTML='';
         startButton.disabled=false;
         stopButton.disabled=true;
         statusEl.innerText='Stopped';

--- a/templates/roi_selection.html
+++ b/templates/roi_selection.html
@@ -46,6 +46,7 @@
         const cam = 1;
 
         const video = document.getElementById("video");
+        video.onload = () => URL.revokeObjectURL(video.src);
         const canvas = document.getElementById("canvas");
         const frameContainer = document.getElementById("frameContainer");
         const ctx = canvas.getContext("2d");
@@ -154,6 +155,8 @@
             };
             socket.onclose = function() {
                 socket = null;
+                video.src = '';
+                ctx.clearRect(0, 0, canvas.width, canvas.height);
                 isStreaming = false;
                 stopBtn.disabled = true;
                 startBtn.disabled = false;
@@ -227,6 +230,8 @@
             } catch (err) {
                 console.error('Failed to stop ROI stream', err);
             }
+            video.src = '';
+            ctx.clearRect(0, 0, canvas.width, canvas.height);
             isStreaming = false;
             hasStarted = false;
             stopBtn.disabled = true;


### PR DESCRIPTION
## Summary
- เคลียร์ภาพวิดีโอและผล ROI เมื่อ WebSocket ปิดหรือหยุดการสตรีม
- รีเซ็ตชื่อเพจและค่าว่างของ ROI ในหน้าสำหรับสตรีม
- ลบเฟรมและแคนวาสเก่าเมื่อหยุดการเลือก ROI

## Testing
- `pytest` *(ล้มเหลว: ต้องการ pytest-asyncio)*

------
https://chatgpt.com/codex/tasks/task_e_68a0981b86a0832b97cc4ebfc72310d1