### PR TITLE
Filter ROI grid by selected page in inference view

### DIFF
--- a/templates/partials/inference_page_content.html
+++ b/templates/partials/inference_page_content.html
@@ -29,6 +29,7 @@ function createController(cellId){
     const pageNameEl=getEl('pageName');
     const roiGrid=getEl('rois');
     let rois=[];
+    let allRois=[];
 
     const startButton=getEl('startButton');
     const stopButton=getEl('stopButton');
@@ -111,12 +112,9 @@ function createController(cellId){
             showAlert('Failed to load ROI file','error');
         }
 
-        rois=roiList.filter(r=>r.type==='roi');
-        if(rois.length>0){
-            renderRoiPlaceholders();
-        }else{
-            roiGrid.innerHTML='';
-        }
+        allRois=roiList.filter(r=>r.type==='roi');
+        rois=[];
+        renderRoiPlaceholders();
 
         const startRes=await fetchWithStatus(`/start_inference/${cam}`,{
             method:'POST',headers:{'Content-Type':'application/json'},
@@ -153,6 +151,8 @@ function createController(cellId){
                 const data=JSON.parse(event.data);
                 if(data.group){
                     pageNameEl.innerText=data.group;
+                    rois=allRois.filter(r=>r.group===data.group);
+                    renderRoiPlaceholders();
                 }else if(data.id){
                     const imgEl=document.getElementById(`${cellId}-roi-${data.id}`);
                     if(imgEl){imgEl.src=`data:image/jpeg;base64,${data.image}`;}
@@ -193,6 +193,9 @@ function createController(cellId){
         if(roiSocket){roiSocket.close();roiSocket=null;}
         video.src='';
         pageNameEl.innerText='';
+        roiGrid.innerHTML='';
+        rois=[];
+        allRois=[];
         startButton.disabled=false;
         stopButton.disabled=true;
         statusEl.innerText='Stopped';
@@ -227,8 +230,9 @@ function createController(cellId){
                     if(!roiPath.startsWith('/'))roiPath=`data_sources/${cfg.name}/${roiPath}`;
                     const roiRes=await fetchWithStatus(`/load_roi_file?path=${encodeURIComponent(roiPath)}`);
                     const roiData=await roiRes.json();
-                    rois=(roiData.rois||[]).filter(r=>r.type==='roi');
-                    if(rois.length>0)renderRoiPlaceholders();
+                    allRois=(roiData.rois||[]).filter(r=>r.type==='roi');
+                    rois=[];
+                    renderRoiPlaceholders();
                 }
                 setRunningUI();
                 running=true;

--- a/tests/test_inference_page_filter_rois.py
+++ b/tests/test_inference_page_filter_rois.py
@@ -1,0 +1,34 @@
+import json
+import re
+import subprocess
+import textwrap
+from pathlib import Path
+
+
+def test_inference_page_filters_rois_by_group():
+    html = Path('templates/partials/inference_page_content.html').read_text()
+    match = re.search(r"function openRoiSocket\(\){[\s\S]*?};\n\s*}\n", html)
+    assert match, 'openRoiSocket function not found'
+    func_text = match.group(0)
+
+    script = textwrap.dedent(f"""
+        let rois = [];
+        let allRois = [{{id:1, group:'A'}}, {{id:2, group:'B'}}];
+        let pageNameEl = {{ innerText: '' }};
+        let roiGrid = {{ innerHTML: '' }};
+        const cam = 'x';
+        const cellId = 'c1';
+        global.location = {{ host: 'localhost' }};
+        global.document = {{ getElementById: () => null }};
+        function renderRoiPlaceholders(list=rois) {{ rois = list; }}
+        global.WebSocket = function(url) {{ return {{}}; }};
+        {func_text}
+        openRoiSocket();
+        roiSocket.onmessage({{ data: JSON.stringify({{group:'B'}}) }});
+        console.log(pageNameEl.innerText + '|' + JSON.stringify(rois));
+    """)
+
+    result = subprocess.run(['node', '-e', script], capture_output=True, text=True, check=True)
+    page, rois_json = result.stdout.strip().split('|')
+    assert page == 'B'
+    assert json.loads(rois_json) == [{'id': 2, 'group': 'B'}]


### PR DESCRIPTION
## Summary
- show only ROIs belonging to the detected page on the inference page
- add test verifying ROI grid filters by group

## Testing
- `pytest` *(fails: pytest-asyncio plugin missing)*
- `pytest tests/test_inference_page_filter_rois.py`

------
https://chatgpt.com/codex/tasks/task_e_68a09b6c35cc832b80dbf5e2b8b175f6