### PR TITLE
ปรับ UI ให้ใช้ Bootstrap เพื่อความสวยงาม

### DIFF
--- a/templates/create_source.html
+++ b/templates/create_source.html
@@ -2,48 +2,51 @@
 {% block title %}Create Source{% endblock %}
 {% block content %}
 
-<h2>Create Source</h2>
-
-<form id="create-form" method="POST" action="/create_source">
-    <div>
-        <label for="name">Name:</label>
-        <input type="text" id="name" name="name" required>
+<div class="container py-4">
+  <h2>Create Source</h2>
+  <form id="create-form" method="POST" action="/create_source" class="card card-body mb-4">
+    <div class="mb-3">
+      <label for="name" class="form-label">Name:</label>
+      <input type="text" id="name" name="name" class="form-control" required>
     </div>
     <div class="mb-3">
-        <label for="source" class="form-label">Source:</label>
-        <input type="text" id="source" name="source" class="form-control" required>
+      <label for="source" class="form-label">Source:</label>
+      <input type="text" id="source" name="source" class="form-control" required>
     </div>
-    <div class="mb-3 d-flex gap-3">
-        <div class="d-flex align-items-center">
-            <label class="me-2 mb-0">
-                <input type="checkbox" id="width-toggle"> Width:
-            </label>
-            <input type="number" id="width" name="width" class="form-control" style="max-width:150px;" disabled>
+    <div class="row mb-3">
+      <div class="col-md-6 d-flex align-items-center">
+        <div class="form-check me-2">
+          <input class="form-check-input" type="checkbox" id="width-toggle">
+          <label class="form-check-label" for="width-toggle">Width:</label>
         </div>
-        <div class="d-flex align-items-center">
-            <label class="me-2 mb-0">
-                <input type="checkbox" id="height-toggle"> Height:
-            </label>
-            <input type="number" id="height" name="height" class="form-control" style="max-width:150px;" disabled>
+        <input type="number" id="width" name="width" class="form-control" style="max-width:150px;" disabled>
+      </div>
+      <div class="col-md-6 d-flex align-items-center mt-2 mt-md-0">
+        <div class="form-check me-2">
+          <input class="form-check-input" type="checkbox" id="height-toggle">
+          <label class="form-check-label" for="height-toggle">Height:</label>
         </div>
+        <input type="number" id="height" name="height" class="form-control" style="max-width:150px;" disabled>
+      </div>
     </div>
     <button type="submit" class="btn btn-primary">Create</button>
-</form>
+  </form>
 
-<h3>Source List</h3>
-<table class="table table-bordered mt-3">
-    <thead>
-        <tr>
-            <th>Name</th>
-            <th>Source</th>
-            <th>Width</th>
-            <th>Height</th>
-            <th>Actions</th>
-        </tr>
+  <h3>Source List</h3>
+  <table class="table table-bordered mt-3">
+    <thead class="table-light">
+      <tr>
+        <th>Name</th>
+        <th>Source</th>
+        <th>Width</th>
+        <th>Height</th>
+        <th>Actions</th>
+      </tr>
     </thead>
     <tbody id="source-table-body">
     </tbody>
-</table>
+  </table>
+</div>
 
 <script>
     const widthToggle = document.getElementById('width-toggle');

--- a/templates/home.html
+++ b/templates/home.html
@@ -1,14 +1,20 @@
 {% extends "base.html" %}
 {% block title %}Home{% endblock %}
 {% block content %}
-<h2>AI Stream Dashboard</h2>
-<p>Welcome! Use the side menu to navigate between features:</p>
-<ul>
-  <li><strong>➕ Create Source</strong> – manage video sources for ROI selection and inference.</li>
-  <li><strong>📐 ROI Selection</strong> – draw Regions of Interest on the live camera stream and save them to a JSON file.</li>
-  <li><strong>🤖 Inference</strong> – load saved ROIs and run AI model inference on those regions.</li>
-</ul>
-<p>This dashboard is designed to help visualize and interact with AI-powered video processing in real time.</p>
+<div class="container py-4">
+  <div class="card">
+    <div class="card-body">
+      <h2 class="card-title">AI Stream Dashboard</h2>
+      <p class="card-text">Welcome! Use the navigation bar to explore features:</p>
+      <ul class="list-group list-group-flush">
+        <li class="list-group-item"><strong>➕ Create Source</strong> – manage video sources for ROI selection and inference.</li>
+        <li class="list-group-item"><strong>📐 ROI Selection</strong> – draw Regions of Interest on the live camera stream and save them to a JSON file.</li>
+        <li class="list-group-item"><strong>🤖 Inference</strong> – load saved ROIs and run AI model inference on those regions.</li>
+      </ul>
+      <p class="mt-3">This dashboard is designed to help visualize and interact with AI-powered video processing in real time.</p>
+    </div>
+  </div>
+</div>
 <script>
   window.addEventListener('DOMContentLoaded', () => {
     showAlert('Welcome to AI Stream Dashboard', 'success');

--- a/templates/partials/alert.html
+++ b/templates/partials/alert.html
@@ -1,36 +1,15 @@
-<div id="alert-box" class="alert" style="display:none;"></div>
+<div id="alert-box" class="alert d-none position-fixed top-0 end-0 m-3" role="alert"></div>
 <script>
 function showAlert(message, type='info', timeout=3000) {
   const box = document.getElementById('alert-box');
   if (!box) return;
+  const bsType = type === 'error' ? 'danger' : type;
   box.textContent = message;
-  box.className = 'alert ' + type;
-  box.style.display = 'block';
+  box.className = `alert alert-${bsType} position-fixed top-0 end-0 m-3`;
+  box.classList.remove('d-none');
   setTimeout(() => {
-    box.style.display = 'none';
+    box.classList.add('d-none');
   }, timeout);
 }
 window.showAlert = showAlert;
 </script>
-<style>
-.alert {
-  position: fixed;
-  top: calc(var(--header-height) + 10px);
-  right: 20px;
-  padding: 10px 20px;
-  border: 1px solid #003366;
-  background-color: #b2d4ff;
-  color: #003366;
-  z-index: 1100;
-}
-.alert.success {
-  background-color: #d4edda;
-  color: #155724;
-  border-color: #c3e6cb;
-}
-.alert.error {
-  background-color: #f8d7da;
-  color: #721c24;
-  border-color: #f5c6cb;
-}
-</style>

--- a/templates/roi_selection.html
+++ b/templates/roi_selection.html
@@ -2,12 +2,13 @@
 {% block title %}ROI Selection{% endblock %}
 {% block content %}
 
-<select id="sourceSelect"></select>
-<button id="startBtn">Start</button>
-<button id="stopBtn" disabled>Stop</button>
-<button id="clearBtn">Clear All</button>
+<div class="mb-3 d-flex align-items-center gap-2">
+  <select id="sourceSelect" class="form-select w-auto"></select>
+  <button id="startBtn" class="btn btn-success">Start</button>
+  <button id="stopBtn" class="btn btn-danger" disabled>Stop</button>
+  <button id="clearBtn" class="btn btn-warning">Clear All</button>
+</div>
 
-<br><br>
 <div class="d-flex">
     <div id="roiToolbar" class="btn-group-vertical me-2">
         <button id="pickBtn" class="btn btn-primary">Pick Points</button>


### PR DESCRIPTION
## Summary
- ปรับหน้า Home ให้อยู่ในรูปแบบการ์ดของ Bootstrap
- ปรับฟอร์ม Create Source ให้ใช้ฟอร์มและ grid ของ Bootstrap
- ปรับระบบแจ้งเตือนและส่วนเลือก ROI ให้ใช้ปุ่มและ alert ของ Bootstrap

## Testing
- `pytest` *(ล้มเหลว: ขาดปลั๊กอิน pytest-asyncio และไม่สามารถติดตั้งได้)*

------
https://chatgpt.com/codex/tasks/task_e_68a113e1bf94832b847ba99901ca7684