### PR TITLE
fix: show alerts above navbar

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -181,3 +181,7 @@ button.delete {
   font-weight: bold;
 }
 
+#alert-box {
+  z-index: 2000;
+}
+


### PR DESCRIPTION
## Summary
- ensure in-page alerts appear above the fixed navbar by increasing z-index

## Testing
- `pytest` *(fails: async def functions are not natively supported; plugin missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a116ac9070832b89d532175efef45f