### PR TITLE
fix: show alerts above navbar

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -181,3 +181,7 @@ button.delete {
   font-weight: bold;
 }
 
+#alert-box {
+  z-index: 9999 !important;
+}
+


### PR DESCRIPTION
## Summary
- bump alert box z-index with !important to ensure it overlays the navbar

## Testing
- `pip install pytest-asyncio` *(fails: Could not find a version that satisfies the requirement pytest-asyncio)*
- `pytest` *(fails: async def functions are not natively supported; plugin missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a116ac9070832b89d532175efef45f