### PR TITLE
fix: position alert box below navbar

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -182,7 +182,9 @@ button.delete {
 }
 
 #alert-box {
+  position: fixed;
+  top: 70px;      /* ปรับตามความสูงของ navbar */
+  right: 0;
   z-index: 9999 !important;
-
 }
 


### PR DESCRIPTION
## Summary
- position the alert box below the navbar and fix it to the top-right

## Testing
- `pytest` *(fails: async def functions are not natively supported)*

------
https://chatgpt.com/codex/tasks/task_e_68a11cd52ac4832bb3564b0edf0fec4a