### PR TITLE
Persist selected source on inference page

### DIFF
--- a/templates/partials/inference_content.html
+++ b/templates/partials/inference_content.html
@@ -36,6 +36,10 @@
         const groupSelect = getEl('groupSelect');
         const roiGrid = getEl('rois');
 
+        sourceSelect.onchange = () => {
+            localStorage.setItem(`${cellId}-source`, sourceSelect.value);
+        };
+
         startButton.onclick = startInference;
         stopButton.onclick = stopInference;
         groupSelect.onchange = switchGroup;
@@ -73,6 +77,10 @@
                         opt.textContent = item.name;
                         sourceSelect.appendChild(opt);
                     });
+                    const stored = localStorage.getItem(`${cellId}-source`) || '';
+                    if (stored) {
+                        sourceSelect.value = stored;
+                    }
                     showAlert('Sources loaded', 'success');
                 }
             } catch (err) {
@@ -149,6 +157,8 @@
                 showAlert('Select source first', 'error');
                 return;
             }
+            localStorage.setItem(`${cellId}-source`, name);
+
             const cfgRes = await fetchWithStatus(`/source_config?name=${encodeURIComponent(name)}`);
             const cfg = await cfgRes.json();
 


### PR DESCRIPTION
## Summary
- remember user's selected source on the inference page
- restore last source from localStorage when reloading the page

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a144463324832ba565ee00927a2e65