### PR TITLE
Persist selected source on inference page

### DIFF
--- a/templates/partials/inference_content.html
+++ b/templates/partials/inference_content.html
@@ -36,6 +36,10 @@
         const groupSelect = getEl('groupSelect');
         const roiGrid = getEl('rois');
 
+        sourceSelect.onchange = () => {
+            localStorage.setItem(`${cellId}-source`, sourceSelect.value);
+        };
+
         startButton.onclick = startInference;
         stopButton.onclick = stopInference;
         groupSelect.onchange = switchGroup;
@@ -73,6 +77,10 @@
                         opt.textContent = item.name;
                         sourceSelect.appendChild(opt);
                     });
+                    const stored = localStorage.getItem(`${cellId}-source`) || '';
+                    if (stored) {
+                        sourceSelect.value = stored;
+                    }
                     showAlert('Sources loaded', 'success');
                 }
             } catch (err) {
@@ -149,6 +157,8 @@
                 showAlert('Select source first', 'error');
                 return;
             }
+            localStorage.setItem(`${cellId}-source`, name);
+
             const cfgRes = await fetchWithStatus(`/source_config?name=${encodeURIComponent(name)}`);
             const cfg = await cfgRes.json();
 

--- a/templates/partials/inference_page_content.html
+++ b/templates/partials/inference_page_content.html
@@ -38,6 +38,9 @@ function createController(cellId){
 
     startButton.onclick=startStream;
     stopButton.onclick=stopStream;
+    sourceSelect.onchange=()=>{
+        localStorage.setItem(`${cellId}-source`,sourceSelect.value);
+    };
 
     async function fetchWithStatus(url,options={}){
         statusEl.innerText='กำลังโหลด...';
@@ -71,6 +74,8 @@ function createController(cellId){
                     opt.textContent=item.name;
                     sourceSelect.appendChild(opt);
                 });
+                const stored=localStorage.getItem(`${cellId}-source`)||'';
+                if(stored)sourceSelect.value=stored;
                 showAlert('Sources loaded','success');
             }
         }catch(e){
@@ -97,6 +102,7 @@ function createController(cellId){
             showAlert('Select source first','error');
             return;
         }
+        localStorage.setItem(`${cellId}-source`,name);
         const cfgRes=await fetchWithStatus(`/source_config?name=${encodeURIComponent(name)}`);
         const cfg=await cfgRes.json();
         let roiPath=cfg.rois;
@@ -213,7 +219,10 @@ function createController(cellId){
                 const srcRes=await fetch(`/roi_stream_status/${cam}`);
                 if(srcRes.ok){
                     const srcData=await srcRes.json();
-                    if(srcData.source)sourceSelect.value=srcData.source;
+                    if(srcData.source){
+                        sourceSelect.value=srcData.source;
+                        localStorage.setItem(`${cellId}-source`,srcData.source);
+                    }
                 }
             }catch(e){}
             if(data.running){


### PR DESCRIPTION
## Summary
- remember user's selected source on inference page
- restore last source from localStorage when reloading or resuming

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a144463324832ba565ee00927a2e65