### PR TITLE
เพิ่มตารางคะแนนของเพจในหน้า inference

### DIFF
--- a/templates/partials/inference_page_content.html
+++ b/templates/partials/inference_page_content.html
@@ -10,6 +10,10 @@
             <div class="video-wrapper">
                 <img id="cam1-video" width="320" height="240" />
                 <p>page: <span id="cam1-pageName"></span></p>
+                <table id="cam1-pageScores" class="table">
+                    <thead><tr><th>Page</th><th>Score</th></tr></thead>
+                    <tbody id="cam1-pageScoresBody"></tbody>
+                </table>
             </div>
         </div>
     </div>
@@ -27,6 +31,7 @@ function createController(cellId){
     const getEl=suffix=>document.getElementById(`${cellId}-${suffix}`);
     const video=getEl('video');
     const pageNameEl=getEl('pageName');
+    const scoreTableBody=getEl('pageScoresBody');
     const roiGrid=getEl('rois');
     let rois=[];
 
@@ -124,6 +129,8 @@ function createController(cellId){
             roiGrid.innerHTML='';
         }
 
+        scoreTableBody.innerHTML='';
+
         const startRes=await fetchWithStatus(`/start_inference/${cam}`,{
             method:'POST',headers:{'Content-Type':'application/json'},
             body:JSON.stringify({...cfg,rois:roiList})
@@ -159,6 +166,19 @@ function createController(cellId){
                 const data=JSON.parse(event.data);
                 if(data.group){
                     pageNameEl.innerText=data.group;
+                    if(Array.isArray(data.scores)){
+                        scoreTableBody.innerHTML='';
+                        data.scores.forEach(item=>{
+                            const tr=document.createElement('tr');
+                            const tdPage=document.createElement('td');
+                            tdPage.textContent=item.page||'';
+                            const tdScore=document.createElement('td');
+                            tdScore.textContent=item.score.toFixed(2);
+                            tr.appendChild(tdPage);
+                            tr.appendChild(tdScore);
+                            scoreTableBody.appendChild(tr);
+                        });
+                    }
                 }else if(data.id){
                     const imgEl=document.getElementById(`${cellId}-roi-${data.id}`);
                     if(imgEl){imgEl.src=`data:image/jpeg;base64,${data.image}`;}
@@ -199,6 +219,7 @@ function createController(cellId){
         if(roiSocket){roiSocket.close();roiSocket=null;}
         video.src='';
         pageNameEl.innerText='';
+        scoreTableBody.innerHTML='';
         startButton.disabled=false;
         stopButton.disabled=true;
         statusEl.innerText='Stopped';
@@ -229,6 +250,7 @@ function createController(cellId){
                 const name=sourceSelect.value;
                 openSocket();
                 openRoiSocket();
+                scoreTableBody.innerHTML='';
                 if(name){
                     const cfgRes=await fetchWithStatus(`/source_config?name=${encodeURIComponent(name)}`);
                     const cfg=await cfgRes.json();


### PR DESCRIPTION
## Summary
- ส่งคะแนนของแต่ละเพจผ่าน WebSocket เพื่อให้ฝั่งหน้าเว็บใช้งานได้
- เพิ่มตารางแสดงชื่อเพจและคะแนนเรียงจากมากไปน้อยใต้ผลลัพธ์หน้า inference

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a1614de4ac832bacb480659dafd10c