### PR TITLE
แก้ปัญหากล้องค้างเมื่อเปิดไม่สำเร็จ

### DIFF
--- a/app.py
+++ b/app.py
@@ -403,7 +403,9 @@ async def start_camera_task(
         width, height = camera_resolutions.get(cam_id, (None, None))
         worker = CameraWorker(src, asyncio.get_running_loop(), width, height)
         if not worker.start():
-            camera_workers[cam_id] = None
+            # ป้องกันไม่ให้กล้องค้างเมื่อเปิดไม่สำเร็จ
+            await worker.stop()
+            camera_workers.pop(cam_id, None)
             return (
                 task,
                 {"status": "error", "message": "open_failed", "cam_id": cam_id},

--- a/camera_worker.py
+++ b/camera_worker.py
@@ -26,6 +26,8 @@ class CameraWorker:
 
     def start(self) -> bool:
         if not self.cap.isOpened():
+            # ปล่อยทรัพยากรทันทีหากไม่สามารถเปิดกล้องได้
+            self.cap.release()
             return False
         if not self._thread.is_alive():
             self._thread.start()
@@ -54,6 +56,8 @@ class CameraWorker:
 
     async def stop(self) -> None:
         self._stop.set()
-        await asyncio.to_thread(self._thread.join)
-        await asyncio.to_thread(self.cap.release)
+        if self._thread.is_alive():
+            await asyncio.to_thread(self._thread.join)
+        if self.cap.isOpened():
+            await asyncio.to_thread(self.cap.release)
         await asyncio.to_thread(cv2.destroyAllWindows)

--- a/tests/test_camera_reopen_after_fail.py
+++ b/tests/test_camera_reopen_after_fail.py
@@ -1,0 +1,46 @@
+import asyncio
+
+
+def test_camera_reopen_after_fail():
+    import app
+
+    class DummyCap:
+        def __init__(self, src):
+            self.src = src
+            self.released = False
+
+        def isOpened(self):
+            return self.src != 5
+
+        def read(self):
+            return True, b"frame"
+
+        def set(self, prop, value):
+            pass
+
+        def release(self):
+            self.released = True
+
+    orig_vc = app.cv2.VideoCapture
+    orig_destroy = app.cv2.destroyAllWindows
+    app.cv2.VideoCapture = DummyCap
+    app.cv2.destroyAllWindows = lambda: None
+    try:
+        async def run():
+            app.camera_sources.clear()
+            app.camera_workers.clear()
+            app.roi_tasks.clear()
+            app.inference_tasks.clear()
+            app.camera_sources["cam1"] = 5
+            task, resp, status = await app.start_camera_task("cam1", app.roi_tasks, app.run_roi_loop)
+            assert status == 400
+            assert app.camera_workers.get("cam1") is None
+            app.camera_sources["cam1"] = 0
+            task, resp, status = await app.start_camera_task("cam1", app.roi_tasks, app.run_roi_loop)
+            assert status == 200
+            await asyncio.sleep(0)
+            app.roi_tasks["cam1"], _, _ = await app.stop_camera_task("cam1", app.roi_tasks)
+        asyncio.run(run())
+    finally:
+        app.cv2.VideoCapture = orig_vc
+        app.cv2.destroyAllWindows = orig_destroy


### PR DESCRIPTION
## สรุป
- ปล่อยทรัพยากรกล้องและล้าง worker เมื่อเปิดกล้องไม่ได้ เพื่อให้ลองใหม่ได้
- เพิ่มการทดสอบกรณีเปิดกล้องล้มเหลวแล้วเปลี่ยนไปใช้กล้องที่ใช้งานได้

## การทดสอบ
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a1ddfa3688832ba236653db4002bb3